### PR TITLE
Adding any codec support for Go language speech sdk

### DIFF
--- a/audio/audio_stream_container_format.go
+++ b/audio/audio_stream_container_format.go
@@ -27,4 +27,7 @@ const (
 
 	// AMRWB Stream ContainerFormat definition for AMRWB. Currently not supported.
 	AMRWB AudioStreamContainerFormat = 0x107
+
+	// ANY Stream ContainerFormat definition when the actual stream format is not known.
+	ANY AudioStreamContainerFormat = 0x108
 )

--- a/samples/recognizer/from_file.go
+++ b/samples/recognizer/from_file.go
@@ -60,17 +60,13 @@ func RecognizeOnceFromCompressedFile(subscription string, region string, file st
 	var containerFormat audio.AudioStreamContainerFormat
 	if strings.Contains(file, ".mulaw") {
 		containerFormat = audio.MULAW
-	} else
-	if strings.Contains(file, ".alaw") {
+	} else if strings.Contains(file, ".alaw") {
 		containerFormat = audio.ALAW
-	} else 
-	if strings.Contains(file, ".mp3") {
+	} else if strings.Contains(file, ".mp3") {
 		containerFormat = audio.MP3
-	} else
-	if strings.Contains(file, ".flac") {
+	} else if strings.Contains(file, ".flac") {
 		containerFormat = audio.FLAC
-	} else
-	if strings.Contains(file, ".opus") {
+	} else if strings.Contains(file, ".opus") {
 		containerFormat = audio.OGGOPUS
 	} else {
 		containerFormat = audio.ANY

--- a/samples/recognizer/from_file.go
+++ b/samples/recognizer/from_file.go
@@ -60,18 +60,20 @@ func RecognizeOnceFromCompressedFile(subscription string, region string, file st
 	var containerFormat audio.AudioStreamContainerFormat
 	if strings.Contains(file, ".mulaw") {
 		containerFormat = audio.MULAW
-	}
+	} else
 	if strings.Contains(file, ".alaw") {
 		containerFormat = audio.ALAW
-	}
+	} else 
 	if strings.Contains(file, ".mp3") {
 		containerFormat = audio.MP3
-	}
+	} else
 	if strings.Contains(file, ".flac") {
 		containerFormat = audio.FLAC
-	}
+	} else
 	if strings.Contains(file, ".opus") {
 		containerFormat = audio.OGGOPUS
+	} else {
+		containerFormat = audio.ANY
 	}
 	format, err := audio.GetCompressedFormat(containerFormat)
 	if err != nil {


### PR DESCRIPTION
When the customer do not know the actual format of the stream they can use ANY format and it will help them to transcribe the file