### PR TITLE
re-enable save file tests for synthesizer

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    
   workflow_dispatch:
 
 env:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    
   workflow_dispatch:
 
 env:

--- a/speech/speech_synthesizer_test.go
+++ b/speech/speech_synthesizer_test.go
@@ -226,8 +226,7 @@ func TestSynthesisToAudioDataStream(t *testing.T) {
 		t.Error("audio data is not equal.")
 	}
 
-	// todo: uncomment following lines after 1.17 released
-	/*saveOutcome := stream.SaveToWavFileAsync("tmp_synthesis.mp3")
+	saveOutcome := stream.SaveToWavFileAsync("tmp_synthesis.mp3")
 	select {
 	case err = <-saveOutcome:
 		if err != nil {
@@ -243,7 +242,7 @@ func TestSynthesisToAudioDataStream(t *testing.T) {
 	file.Read(audioData4)
 	if !bytes.Equal(audioData2, audioData4) {
 		t.Error("audio data is not equal.")
-	}*/
+	}
 }
 
 func TestSynthesisWithInvalidVoice(t *testing.T) {


### PR DESCRIPTION
there was a bug when saving wave file on macOS before `1.17`