### PR TITLE
Add duration property of speech synthesis result, update word boundary

### DIFF
--- a/common/property_id.go
+++ b/common/property_id.go
@@ -178,6 +178,20 @@ const (
 	// partial results by omitting words in the end.
 	SpeechServiceResponseTranslationRequestStablePartialResult PropertyID = 4100
 
+	// SpeechServiceResponseRequestWordBoundary is a boolean value specifying whether to request WordBoundary events.
+	// Added in version 1.21.0.
+	SpeechServiceResponseRequestWordBoundary PropertyID = 4200
+
+	// SpeechServiceResponseRequestPunctuationBoundary is a boolean value specifying whether to request punctuation boundary
+	// in WordBoundary Events. Default is true.
+	// Added in version 1.21.0.
+	SpeechServiceResponseRequestPunctuationBoundary PropertyID = 4201
+
+	// SpeechServiceResponseRequestSentenceBoundary ia a boolean value specifying whether to request sentence boundary
+	// in WordBoundary Events. Default is false.
+	// Added in version 1.21.0.
+	SpeechServiceResponseRequestSentenceBoundary PropertyID = 4202
+
 	// SpeechServiceResponseJSONResult is the Cognitive Services Speech Service response output (in JSON format). This
 	// property is available on recognition result objects only.
 	SpeechServiceResponseJSONResult PropertyID = 5000

--- a/common/speech_synthesis_boundary_type.go
+++ b/common/speech_synthesis_boundary_type.go
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+
+package common
+
+// SpeechSynthesisBoundaryType defines the boundary type of speech synthesis boundary event.
+type SpeechSynthesisBoundaryType int
+
+const (
+	// WordBoundary indicates word boundary.
+	WordBoundary SpeechSynthesisBoundaryType = 1
+
+	// PunctuationBoundary indicates punctuation boundary.
+	PunctuationBoundary SpeechSynthesisBoundaryType = 2
+
+	// SentenceBoundary indicates sentence boundary.
+	SentenceBoundary SpeechSynthesisBoundaryType = 3
+)

--- a/common/speech_synthesis_output_format.go
+++ b/common/speech_synthesis_output_format.go
@@ -95,4 +95,20 @@ const (
 
 	// Riff8Khz8BitMonoALaw stands for riff-8khz-8bit-mono-alaw
 	Riff8Khz8BitMonoALaw SpeechSynthesisOutputFormat = 29
+
+	// Webm24Khz16Bit24KbpsMonoOpus stands for webm-24khz-16bit-24kbps-mono-opus
+	// Audio compressed by OPUS codec in a WebM container, with bitrate of 24kbps, optimized for IoT scenario.
+	Webm24Khz16Bit24KbpsMonoOpus SpeechSynthesisOutputFormat = 30
+
+	// Audio16Khz16Bit32KbpsMonoOpus stands for audio-16khz-16bit-32kbps-mono-opus
+	// Audio compressed by OPUS codec without container, with bitrate of 32kbps.
+	Audio16Khz16Bit32KbpsMonoOpus SpeechSynthesisOutputFormat = 31
+
+	// Audio24Khz16Bit48KbpsMonoOpus stands for audio-24khz-16bit-48kbps-mono-opus
+	// Audio compressed by OPUS codec without container, with bitrate of 48kbps.
+	Audio24Khz16Bit48KbpsMonoOpus SpeechSynthesisOutputFormat = 32
+
+	// Audio24Khz16Bit24KbpsMonoOpus stands for audio-24khz-16bit-24kbps-mono-opus
+	// Audio compressed by OPUS codec without container, with bitrate of 24kbps.
+	Audio24Khz16Bit24KbpsMonoOpus SpeechSynthesisOutputFormat = 33
 )

--- a/speech/speech_synthesis_bookmark_event_args.go
+++ b/speech/speech_synthesis_bookmark_event_args.go
@@ -14,9 +14,13 @@ import "C"
 
 // SpeechSynthesisBookmarkEventArgs represents the speech synthesis bookmark event arguments.
 type SpeechSynthesisBookmarkEventArgs struct {
-	handle      C.SPXHANDLE
+	handle C.SPXHANDLE
+
+	// AudioOffset is the audio offset of the bookmark event, in ticks (100 nanoseconds).
 	AudioOffset uint64
-	Text        string
+
+	// Text is the text of the bookmark.
+	Text string
 }
 
 // Close releases the underlying resources
@@ -36,7 +40,7 @@ func NewSpeechSynthesisBookmarkEventArgsFromHandle(handle common.SPXHandle) (*Sp
 	}
 	event.AudioOffset = uint64(cAudioOffset)
 	/* Text */
-	value := C.synthesizer_bookmark_event_get_text(event.handle)
+	value := C.synthesizer_event_get_text(event.handle)
 	event.Text = C.GoString(value)
 	C.property_bag_free_string(value)
 	return event, nil

--- a/speech/speech_synthesis_viseme_event_args.go
+++ b/speech/speech_synthesis_viseme_event_args.go
@@ -14,10 +14,16 @@ import "C"
 
 // SpeechSynthesisVisemeEventArgs represents the speech synthesis viseme event arguments.
 type SpeechSynthesisVisemeEventArgs struct {
-	handle      C.SPXHANDLE
+	handle C.SPXHANDLE
+
+	// AudioOffset is the audio offset of the viseme event, in ticks (100 nanoseconds).
 	AudioOffset uint64
-	VisemeID    uint
-	Animation   string
+
+	// VisemeID is the viseme ID.
+	VisemeID uint
+
+	// Animation is the animation.
+	Animation string
 }
 
 // Close releases the underlying resources


### PR DESCRIPTION
- Add audio duration in synthesis result;
- Add punctuation and sentence boundary

We need to wait for 1.21 release before merging this PR.