### PR TITLE
Add AudioStreamWaveFormat with ALAW, MULAW support

### DIFF
--- a/audio/audio_stream_container_format.go
+++ b/audio/audio_stream_container_format.go
@@ -31,3 +31,18 @@ const (
 	// ANY Stream ContainerFormat definition when the actual stream format is not known.
 	ANY AudioStreamContainerFormat = 0x108
 )
+
+// AudioStreamWaveFormat represents the format specified inside WAV container which are sent directly as encoded to the speech service.
+type AudioStreamWaveFormat int //nolint:revive
+
+const (
+	// AudioStreamWaveFormat definition for PCM (pulse-code modulated) data in integer format.
+	WAVE_PCM AudioStreamWaveFormat = 0x0001
+
+	// AudioStreamWaveFormat definition A-law-encoded format.
+	WAVE_ALAW AudioStreamWaveFormat = 0x0006
+
+	// AudioStreamWaveFormat definition for Mu-law-encoded format.
+	WAVE_MULAW AudioStreamWaveFormat = 0x0007
+
+)

--- a/audio/audio_stream_container_format.go
+++ b/audio/audio_stream_container_format.go
@@ -37,12 +37,12 @@ type AudioStreamWaveFormat int //nolint:revive
 
 const (
 	// AudioStreamWaveFormat definition for PCM (pulse-code modulated) data in integer format.
-	WAVE_PCM AudioStreamWaveFormat = 0x0001
+	WavePCM AudioStreamWaveFormat = 0x0001
 
 	// AudioStreamWaveFormat definition A-law-encoded format.
-	WAVE_ALAW AudioStreamWaveFormat = 0x0006
+	WaveALAW AudioStreamWaveFormat = 0x0006
 
 	// AudioStreamWaveFormat definition for Mu-law-encoded format.
-	WAVE_MULAW AudioStreamWaveFormat = 0x0007
+	WaveMULAW AudioStreamWaveFormat = 0x0007
 
 )

--- a/audio/audio_stream_format.go
+++ b/audio/audio_stream_format.go
@@ -32,6 +32,23 @@ func GetDefaultInputFormat() (*AudioStreamFormat, error) {
 	return format, nil
 }
 
+// GetWaveFormat creates an audio stream format object with the specified waveformat characteristics.
+func GetWaveFormat(samplesPerSecond uint32, bitsPerSample uint8, channels uint8, waveFormat AudioStreamWaveFormat) (*AudioStreamFormat, error) {
+	var handle C.SPXHANDLE
+	ret := uintptr(C.audio_stream_format_create_from_waveformat(
+		&handle,
+		(C.uint32_t)(samplesPerSecond),
+		(C.uint8_t)(bitsPerSample),
+		(C.uint8_t)(channels),
+		(C.Audio_Stream_Wave_Format)(waveFormat)))
+	if ret != C.SPX_NOERROR {
+		return nil, common.NewCarbonError(ret)
+	}
+	format := new(AudioStreamFormat)
+	format.handle = handle
+	return format, nil
+}
+
 // GetWaveFormatPCM creates an audio stream format object with the specified PCM waveformat characteristics.
 // Note: Currently, only WAV / PCM with 16-bit samples, 16 kHz sample rate, and a single channel (Mono) is supported. When
 // used with Conversation Transcription, eight channels are supported.

--- a/samples/main.go
+++ b/samples/main.go
@@ -31,6 +31,7 @@ func main() {
 	samples := functionMap{
 		"speech_recognizer:RecognizeOnceFromWavFile":        recognizer.RecognizeOnceFromWavFile,
 		"speech_recognizer:RecognizeOnceFromCompressedFile": recognizer.RecognizeOnceFromCompressedFile,
+		"speech_recognizer:RecognizeOnceFromALAWFile":       recognizer.RecognizeOnceFromALAWFile,
 		"speech_recognizer:ContinuousFromMicrophone":        recognizer.ContinuousFromMicrophone,
 		"speech_recognizer:RecognizeContinuousUsingWrapper": recognizer.RecognizeContinuousUsingWrapper,
 		"dialog_service_connector:ListenOnce":               dialog_service_connector.ListenOnce,

--- a/samples/recognizer/from_file.go
+++ b/samples/recognizer/from_file.go
@@ -128,7 +128,7 @@ func RecognizeOnceFromCompressedFile(subscription string, region string, file st
 
 func RecognizeOnceFromALAWFile(subscription string, region string, file string) {
 	var waveFormat audio.AudioStreamWaveFormat
-	waveFormat = audio.WAVE_ALAW
+	waveFormat = audio.WaveALAW
 	format, err := audio.GetWaveFormat(8000, 16, 1, waveFormat)
 	if err != nil {
 		fmt.Println("Got an error: ", err)


### PR DESCRIPTION
This PR adds new audio API method to support ALAW and MULAW wave format configuration.

// GetWaveFormat creates an audio stream format object with the specified waveformat characteristics.
func GetWaveFormat(samplesPerSecond uint32, bitsPerSample uint8, channels uint8, waveFormat AudioStreamWaveFormat)

Customer can use the method to create AudioStreamFormat with the specific format tag inside the wave header. The supported formats specified inside AudioStreamWaveFormat are WAVE_PCM, WAVE_ALAW & WAVE_MULAW. When the AudioStreamFormat has been configured using this method, audio data will be sent directly to the service.

This PR adds also basic sample for ALAW encoded file streaming to the service.

Related customer issue; https://github.com/microsoft/cognitive-services-speech-sdk-go/issues/81