### PR TITLE
Fix #108

### DIFF
--- a/speech/auto_detect_source_language_config.go
+++ b/speech/auto_detect_source_language_config.go
@@ -74,6 +74,7 @@ func NewAutoDetectSourceLanguageConfigFromLanguageConfigs(configs []*SourceLangu
 		}
 		if first {
 			ret = uintptr(C.create_auto_detect_source_lang_config_from_source_lang_config(&handle, c.getHandle()))
+			first = false
 			if ret != C.SPX_NOERROR {
 				return nil, common.NewCarbonError(ret)
 			}


### PR DESCRIPTION
The flag `first` use in NewAutoDetectSourceLanguageConfigFromLanguageConfigs should set to false after use it.