### PR TITLE
Remove intent recognition support

### DIFF
--- a/common/property_id.go
+++ b/common/property_id.go
@@ -8,8 +8,7 @@ package common
 type PropertyID int
 
 const (
-	// SpeechServiceConnectionKey is the Cognitive Services Speech Service subscription key. If you are using an
-	// intent recognizer, you need to specify the LUIS endpoint key for your particular LUIS app. Under normal
+	// SpeechServiceConnectionKey is the Cognitive Services Speech Service subscription key. Under normal
 	// circumstances, you shouldn't have to use this property directly.
 	// Instead, use NewSpeechConfigFromSubscription.
 	SpeechServiceConnectionKey PropertyID = 1000
@@ -87,11 +86,6 @@ const (
 
 	// SpeechServiceConnectionTranslationFeatures is the translation features. For internal use.
 	SpeechServiceConnectionTranslationFeatures PropertyID = 2002
-
-	// SpeechServiceConnectionIntentRegion is the Language Understanding Service region. Under normal circumstances, you
-	// shouldn't have to use this property directly.
-	// Instead use LanguageUnderstandingModel.
-	SpeechServiceConnectionIntentRegion PropertyID = 2003
 
 	// SpeechServiceConnectionRecoMode is the Cognitive Services Speech Service recognition mode. Can be "INTERACTIVE",
 	// "CONVERSATION" or "DICTATION".
@@ -207,7 +201,7 @@ const (
 	SpeechServiceResponseJSONErrorDetails PropertyID = 5001
 
 	// SpeechServiceResponseRecognitionLatencyMs is the recognition latency in milliseconds. Read-only, available on final
-	// speech/translation/intent results. This measures the latency between when an audio input is received by the SDK, and
+	// speech/translation results. This measures the latency between when an audio input is received by the SDK, and
 	// the moment the final result is received from the service. The SDK computes the time difference between the last audio
 	// fragment from the audio input that is contributing to the final result, and the time the final result is received from
 	// the speech service.
@@ -262,10 +256,6 @@ const (
 
 	// CancellationDetailsReasonDetailedText is the cancellation detailed text. Currently unused.
 	CancellationDetailsReasonDetailedText PropertyID = 6002
-
-	// LanguageUnderstandingServiceResponseJSONResult is the Language Understanding Service response output (in JSON format).
-	// Available via IntentRecognitionResult.Properties.
-	LanguageUnderstandingServiceResponseJSONResult PropertyID = 7000
 
 	// AudioConfigDeviceNameForCapture is the device name for audio capture. Under normal circumstances, you shouldn't have
 	// to use this property directly.

--- a/common/result_reason.go
+++ b/common/result_reason.go
@@ -20,11 +20,10 @@ const (
 	// Speech Recognition is now complete for this phrase.
 	RecognizedSpeech ResultReason = 3
 
-	// RecognizingIntent indicates the intent result contains hypothesis text and intent.
+	// This result reason is deprecated and not used anymore.
 	RecognizingIntent ResultReason = 4
 
-	// RecognizedIntent indicates the intent result contains final text and intent.
-	// Speech Recognition and Intent determination are now complete for this phrase.
+	// This result reason is deprecated and not used anymore.
 	RecognizedIntent ResultReason = 5
 
 	// TranslatingSpeech indicates the translation result contains hypothesis text and its translation(s).

--- a/speech/speech_config.go
+++ b/speech/speech_config.go
@@ -14,7 +14,7 @@ import (
 // #include <speechapi_c_speech_config.h>
 import "C"
 
-// SpeechConfig is the class that defines configurations for speech / intent recognition, or speech synthesis.
+// SpeechConfig is the class that defines configurations for speech recognition or speech synthesis.
 type SpeechConfig struct {
 	handle     C.SPXHANDLE
 	properties *common.PropertyCollection
@@ -162,13 +162,13 @@ func NewSpeechConfigFromHost(host string) (*SpeechConfig, error) {
 	return NewSpeechConfigFromHandle(handle2uintptr(handle))
 }
 
-// SubscriptionKey is the subscription key that is used to create Speech Recognizer or Intent Recognizer or Translation
+// SubscriptionKey is the subscription key that is used to create Speech Recognizer or Translation
 // Recognizer or Speech Synthesizer
 func (config *SpeechConfig) SubscriptionKey() string {
 	return config.GetProperty(common.SpeechServiceConnectionKey)
 }
 
-// Region is the region key that used to create Speech Recognizer or Intent Recognizer or Translation Recognizer or
+// Region is the region key that used to create Speech Recognizer or Translation Recognizer or
 // Speech Synthesizer.
 func (config *SpeechConfig) Region() string {
 	return config.GetProperty(common.SpeechServiceConnectionRegion)


### PR DESCRIPTION
Remove intent recognition support (just a couple of properties and some comments) due to the service retirement as announced: https://learn.microsoft.com/en-us/azure/ai-services/speech-service/intent-recognition