### PR TITLE
Close AudioStreamFormat resource when using default input format

### DIFF
--- a/audio/audio_input_stream.go
+++ b/audio/audio_input_stream.go
@@ -223,5 +223,6 @@ func CreatePullStream(callback PullAudioInputStreamCallback) (*PullAudioInputStr
 	if err != nil {
 		return nil, err
 	}
+	defer format.Close()
 	return CreatePullStreamFromFormat(callback, format)
 }


### PR DESCRIPTION
Close the `AudioStreamFormat` resource in `CreatePushAudioInputStream()` and `CreatePullStream()` when using the internal default input format.