### PR TITLE
Add conversation transcriber samples and update Speech SDK to 1.48.0

### DIFF
--- a/samples/.gitignore
+++ b/samples/.gitignore
@@ -1,1 +1,2 @@
 samples
+samples.exe

--- a/samples/conversation_transcriber/doc.go
+++ b/samples/conversation_transcriber/doc.go
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+
+// Package conversation_transcriber contains samples demonstrating usage of the conversation transcriber.
+package conversation_transcriber

--- a/samples/conversation_transcriber/from_file.go
+++ b/samples/conversation_transcriber/from_file.go
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+
+package conversation_transcriber
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/audio"
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/common"
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/speech"
+)
+
+// TranscribeFromFile performs conversation transcription from an audio file.
+// This sample demonstrates how to transcribe a conversation from a WAV file with speaker identification.
+func TranscribeFromFile(subscription string, region string, file string) {
+	if file == "" {
+		fmt.Println("Error: file path is required for this sample")
+		return
+	}
+
+	audioConfig, err := audio.NewAudioConfigFromWavFileInput(file)
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer audioConfig.Close()
+
+	config, err := speech.NewSpeechConfigFromSubscription(subscription, region)
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer config.Close()
+
+	transcriber, err := speech.NewConversationTranscriberFromConfig(config, audioConfig)
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer transcriber.Close()
+
+	// Channel to signal when transcription is done
+	done := make(chan bool)
+
+	transcriber.SessionStarted(func(event speech.SessionEventArgs) {
+		defer event.Close()
+		fmt.Println("Session Started (ID=", event.SessionID, ")")
+	})
+
+	transcriber.SessionStopped(func(event speech.SessionEventArgs) {
+		defer event.Close()
+		fmt.Println("Session Stopped (ID=", event.SessionID, ")")
+		done <- true
+	})
+
+	transcriber.Transcribing(func(event speech.ConversationTranscriptionEventArgs) {
+		defer event.Close()
+		fmt.Println("Transcribing - Speaker:", event.Result.SpeakerID, "Text:", event.Result.Text)
+	})
+
+	transcriber.Transcribed(func(event speech.ConversationTranscriptionEventArgs) {
+		defer event.Close()
+		if event.Result.Reason == common.RecognizedSpeech {
+			fmt.Println("Transcribed - Speaker:", event.Result.SpeakerID, "Text:", event.Result.Text)
+		} else if event.Result.Reason == common.NoMatch {
+			fmt.Println("No speech could be recognized")
+		}
+	})
+
+	transcriber.Canceled(func(event speech.ConversationTranscriptionCanceledEventArgs) {
+		defer event.Close()
+		fmt.Println("Canceled: ", event.ErrorDetails)
+		fmt.Println("Cancellation Reason: ", event.Reason)
+		if event.Reason == common.EndOfStream {
+			fmt.Println("End of audio stream reached")
+		}
+		done <- true
+	})
+
+	// Start transcription
+	transcriber.StartTranscribingAsync()
+
+	// Wait for transcription to complete with timeout
+	select {
+	case <-done:
+		fmt.Println("Transcription completed")
+	case <-time.After(5 * time.Minute):
+		fmt.Println("Transcription timed out")
+	}
+
+	transcriber.StopTranscribingAsync()
+}

--- a/samples/conversation_transcriber/from_microphone.go
+++ b/samples/conversation_transcriber/from_microphone.go
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+
+package conversation_transcriber
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/audio"
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/speech"
+)
+
+func sessionStartedHandler(event speech.SessionEventArgs) {
+	defer event.Close()
+	fmt.Println("Session Started (ID=", event.SessionID, ")")
+}
+
+func sessionStoppedHandler(event speech.SessionEventArgs) {
+	defer event.Close()
+	fmt.Println("Session Stopped (ID=", event.SessionID, ")")
+}
+
+func transcribingHandler(event speech.ConversationTranscriptionEventArgs) {
+	defer event.Close()
+	fmt.Println("Transcribing - Speaker:", event.Result.SpeakerID, "Text:", event.Result.Text)
+}
+
+func transcribedHandler(event speech.ConversationTranscriptionEventArgs) {
+	defer event.Close()
+	fmt.Println("Transcribed - Speaker:", event.Result.SpeakerID, "Text:", event.Result.Text)
+}
+
+func canceledHandler(event speech.ConversationTranscriptionCanceledEventArgs) {
+	defer event.Close()
+	fmt.Println("Received a cancellation: ", event.ErrorDetails)
+	fmt.Println("Cancellation Reason: ", event.Reason)
+}
+
+// ContinuousFromMicrophone performs continuous conversation transcription from the default microphone.
+// This sample demonstrates how to transcribe a conversation with speaker identification.
+func ContinuousFromMicrophone(subscription string, region string, _ string) {
+	audioConfig, err := audio.NewAudioConfigFromDefaultMicrophoneInput()
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer audioConfig.Close()
+
+	config, err := speech.NewSpeechConfigFromSubscription(subscription, region)
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer config.Close()
+
+	transcriber, err := speech.NewConversationTranscriberFromConfig(config, audioConfig)
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer transcriber.Close()
+
+	transcriber.SessionStarted(sessionStartedHandler)
+	transcriber.SessionStopped(sessionStoppedHandler)
+	transcriber.Transcribing(transcribingHandler)
+	transcriber.Transcribed(transcribedHandler)
+	transcriber.Canceled(canceledHandler)
+
+	transcriber.StartTranscribingAsync()
+	defer transcriber.StopTranscribingAsync()
+
+	fmt.Println("Conversation transcription started. Press Enter to stop...")
+	bufio.NewReader(os.Stdin).ReadBytes('\n')
+}

--- a/samples/go.mod
+++ b/samples/go.mod
@@ -2,4 +2,6 @@ module github.com/Microsoft/cognitive-services-speech-sdk-go/samples
 
 require github.com/Microsoft/cognitive-services-speech-sdk-go v1.33.0
 
+replace github.com/Microsoft/cognitive-services-speech-sdk-go => ../
+
 go 1.13

--- a/samples/main.go
+++ b/samples/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/samples/conversation_transcriber"
 	"github.com/Microsoft/cognitive-services-speech-sdk-go/samples/dialog_service_connector"
 	"github.com/Microsoft/cognitive-services-speech-sdk-go/samples/recognizer"
 	"github.com/Microsoft/cognitive-services-speech-sdk-go/samples/synthesizer"
@@ -33,6 +34,8 @@ func main() {
 		"speech_recognizer:RecognizeOnceFromALAWFile":       recognizer.RecognizeOnceFromALAWFile,
 		"speech_recognizer:ContinuousFromMicrophone":        recognizer.ContinuousFromMicrophone,
 		"speech_recognizer:RecognizeContinuousUsingWrapper": recognizer.RecognizeContinuousUsingWrapper,
+		"conversation_transcriber:ContinuousFromMicrophone": conversation_transcriber.ContinuousFromMicrophone,
+		"conversation_transcriber:TranscribeFromFile":       conversation_transcriber.TranscribeFromFile,
 		"dialog_service_connector:ListenOnce":               dialog_service_connector.ListenOnce,
 		"dialog_service_connector:KWS":                      dialog_service_connector.KWS,
 		"dialog_service_connector:ListenOnceFromStream":     dialog_service_connector.ListenOnceFromStream,


### PR DESCRIPTION
- Add conversation_transcriber package with samples for:
  - ContinuousFromMicrophone: Real-time transcription from microphone
  - TranscribeFromFile: Transcription from WAV audio files
- Both samples demonstrate speaker identification (SpeakerID)
- Update Speech SDK version from 1.42.0/1.43.0 to 1.48.0 in:
  - .github/workflows/go.yml
  - .github/workflows/lint.yml
  - ci/azure-pipelines.yml