### PR TITLE
Fix AutoDetectSourceLangConfig API Misspellings; add backward-compatible alias and tests

### DIFF
--- a/samples/main.go
+++ b/samples/main.go
@@ -29,18 +29,20 @@ func printHelp(executableName string, samples functionMap) {
 
 func main() {
 	samples := functionMap{
-		"speech_recognizer:RecognizeOnceFromWavFile":        recognizer.RecognizeOnceFromWavFile,
-		"speech_recognizer:RecognizeOnceFromCompressedFile": recognizer.RecognizeOnceFromCompressedFile,
-		"speech_recognizer:RecognizeOnceFromALAWFile":       recognizer.RecognizeOnceFromALAWFile,
-		"speech_recognizer:ContinuousFromMicrophone":        recognizer.ContinuousFromMicrophone,
-		"speech_recognizer:RecognizeContinuousUsingWrapper": recognizer.RecognizeContinuousUsingWrapper,
-		"conversation_transcriber:ContinuousFromMicrophone": conversation_transcriber.ContinuousFromMicrophone,
-		"conversation_transcriber:TranscribeFromFile":       conversation_transcriber.TranscribeFromFile,
-		"dialog_service_connector:ListenOnce":               dialog_service_connector.ListenOnce,
-		"dialog_service_connector:KWS":                      dialog_service_connector.KWS,
-		"dialog_service_connector:ListenOnceFromStream":     dialog_service_connector.ListenOnceFromStream,
-		"speech_synthesizer:SynthesisToSpeaker":             synthesizer.SynthesisToSpeaker,
-		"speech_synthesizer:SynthesisToAudioDataStream":     synthesizer.SynthesisToAudioDataStream,
+		"speech_recognizer:RecognizeOnceFromWavFile":                    recognizer.RecognizeOnceFromWavFile,
+		"speech_recognizer:RecognizeOnceFromCompressedFile":             recognizer.RecognizeOnceFromCompressedFile,
+		"speech_recognizer:RecognizeOnceFromALAWFile":                   recognizer.RecognizeOnceFromALAWFile,
+		"speech_recognizer:RecognizeOnceFromAutoDetectSourceLangConfig": recognizer.RecognizeOnceFromAutoDetectSourceLangConfig,
+		"speech_recognizer:ContinuousFromMicrophone":                    recognizer.ContinuousFromMicrophone,
+		"speech_recognizer:RecognizeContinuousUsingWrapper":             recognizer.RecognizeContinuousUsingWrapper,
+		"conversation_transcriber:ContinuousFromMicrophone":             conversation_transcriber.ContinuousFromMicrophone,
+		"conversation_transcriber:TranscribeFromFile":                   conversation_transcriber.TranscribeFromFile,
+		"dialog_service_connector:ListenOnce":                           dialog_service_connector.ListenOnce,
+		"dialog_service_connector:KWS":                                  dialog_service_connector.KWS,
+		"dialog_service_connector:ListenOnceFromStream":                 dialog_service_connector.ListenOnceFromStream,
+		"speech_synthesizer:SynthesisToSpeaker":                         synthesizer.SynthesisToSpeaker,
+		"speech_synthesizer:SynthesisToAudioDataStream":                 synthesizer.SynthesisToAudioDataStream,
+		"speech_synthesizer:SynthesisFromAutoDetectSourceLangConfig":    synthesizer.SynthesisFromAutoDetectSourceLangConfig,
 	}
 	args := os.Args[1:]
 	if len(args) != 4 {

--- a/samples/recognizer/auto_detect.go
+++ b/samples/recognizer/auto_detect.go
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+
+package recognizer
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/audio"
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/speech"
+)
+
+func RecognizeOnceFromAutoDetectSourceLangConfig(subscription string, region string, file string) {
+	audioConfig, err := audio.NewAudioConfigFromWavFileInput(file)
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer audioConfig.Close()
+	config, err := speech.NewSpeechConfigFromSubscription(subscription, region)
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer config.Close()
+	languageConfig, err := speech.NewAutoDetectSourceLanguageConfigFromLanguages([]string{"en-US", "de-DE"})
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer languageConfig.Close()
+	speechRecognizer, err := speech.NewSpeechRecognizerFromAutoDetectSourceLangConfig(config, languageConfig, audioConfig)
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer speechRecognizer.Close()
+	task := speechRecognizer.RecognizeOnceAsync()
+	var outcome speech.SpeechRecognitionOutcome
+	select {
+	case outcome = <-task:
+	case <-time.After(10 * time.Second):
+		fmt.Println("Timed out")
+		return
+	}
+	defer outcome.Close()
+	if outcome.Error != nil {
+		fmt.Println("Got an error: ", outcome.Error)
+		return
+	}
+	fmt.Println("Got a recognition!")
+	fmt.Println(outcome.Result.Text)
+}

--- a/samples/synthesizer/auto_detect.go
+++ b/samples/synthesizer/auto_detect.go
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+
+package synthesizer
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/common"
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/speech"
+)
+
+func SynthesisFromAutoDetectSourceLangConfig(subscription string, region string, file string) {
+	_ = file
+	config, err := speech.NewSpeechConfigFromSubscription(subscription, region)
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer config.Close()
+	languageConfig, err := speech.NewAutoDetectSourceLanguageConfigFromOpenRange()
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer languageConfig.Close()
+	speechSynthesizer, err := speech.NewSpeechSynthesizerFromAutoDetectSourceLangConfig(config, languageConfig, nil)
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer speechSynthesizer.Close()
+	task := speechSynthesizer.SpeakTextAsync("Hello, world.")
+	var outcome speech.SpeechSynthesisOutcome
+	select {
+	case outcome = <-task:
+	case <-time.After(30 * time.Second):
+		fmt.Println("Timed out")
+		return
+	}
+	defer outcome.Close()
+	if outcome.Error != nil {
+		fmt.Println("Got an error: ", outcome.Error)
+		return
+	}
+	if outcome.Result.Reason != common.SynthesizingAudioCompleted {
+		fmt.Println("Synthesis failed with reason:", outcome.Result.Reason)
+		return
+	}
+	fmt.Println("Speech synthesized successfully with auto-detect source language config.")
+}

--- a/speech/speech_recognizer.go
+++ b/speech/speech_recognizer.go
@@ -73,8 +73,8 @@ func NewSpeechRecognizerFromConfig(config *SpeechConfig, audioConfig *audio.Audi
 	return newSpeechRecognizerFromHandle(handle)
 }
 
-// NewSpeechRecognizerFomAutoDetectSourceLangConfig creates a speech recognizer from a speech config, auto detection source language config and audio config
-func NewSpeechRecognizerFomAutoDetectSourceLangConfig(config *SpeechConfig, langConfig *AutoDetectSourceLanguageConfig, audioConfig *audio.AudioConfig) (*SpeechRecognizer, error) {
+// NewSpeechRecognizerFromAutoDetectSourceLangConfig creates a speech recognizer from a speech config, auto detection source language config and audio config
+func NewSpeechRecognizerFromAutoDetectSourceLangConfig(config *SpeechConfig, langConfig *AutoDetectSourceLanguageConfig, audioConfig *audio.AudioConfig) (*SpeechRecognizer, error) {
 	var handle C.SPXHANDLE
 	if config == nil {
 		return nil, common.NewCarbonError(uintptr(C.SPXERR_INVALID_ARG))
@@ -95,6 +95,12 @@ func NewSpeechRecognizerFomAutoDetectSourceLangConfig(config *SpeechConfig, lang
 		return nil, common.NewCarbonError(ret)
 	}
 	return newSpeechRecognizerFromHandle(handle)
+}
+
+// NewSpeechRecognizerFomAutoDetectSourceLangConfig is a deprecated alias for NewSpeechRecognizerFromAutoDetectSourceLangConfig.
+// Deprecated: Use NewSpeechRecognizerFromAutoDetectSourceLangConfig instead.
+func NewSpeechRecognizerFomAutoDetectSourceLangConfig(config *SpeechConfig, langConfig *AutoDetectSourceLanguageConfig, audioConfig *audio.AudioConfig) (*SpeechRecognizer, error) {
+	return NewSpeechRecognizerFromAutoDetectSourceLangConfig(config, langConfig, audioConfig)
 }
 
 // NewSpeechRecognizerFromSourceLanguageConfig creates a speech recognizer from a speech config, source language config and audio config

--- a/speech/speech_recognizer_test.go
+++ b/speech/speech_recognizer_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Microsoft/cognitive-services-speech-sdk-go/audio"
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/common"
 )
 
 func createSpeechRecognizerFromSubscriptionRegionAndAudioConfig(t *testing.T, subscription string, region string, audioConfig *audio.AudioConfig) *SpeechRecognizer {
@@ -273,4 +274,54 @@ func TestPhraseListGrammarWithoutGrammar(t *testing.T) {
 
 func TestPhraseListGrammarWithGrammar(t *testing.T) {
 	testPhraseList(t, true)
+}
+
+func TestRecognitionWithLanguageAutoDetection(t *testing.T) {
+	subscription := os.Getenv("SPEECH_SUBSCRIPTION_KEY")
+	region := os.Getenv("SPEECH_SUBSCRIPTION_REGION")
+	config, err := NewSpeechConfigFromSubscription(subscription, region)
+	if err != nil {
+		t.Error("Got an error: ", err)
+		return
+	}
+	defer config.Close()
+	languageConfig, err := NewAutoDetectSourceLanguageConfigFromLanguages([]string{"en-US", "de-DE"})
+	if err != nil {
+		t.Error("Got an error: ", err)
+		return
+	}
+	defer languageConfig.Close()
+	audioConfig, err := audio.NewAudioConfigFromWavFileInput("../test_files/turn_on_the_lamp.wav")
+	if err != nil {
+		t.Error("Got an error: ", err)
+		return
+	}
+	defer audioConfig.Close()
+	recognizer, err := NewSpeechRecognizerFromAutoDetectSourceLangConfig(config, languageConfig, audioConfig)
+	if err != nil {
+		t.Error("Got an error: ", err)
+		return
+	}
+	if recognizer == nil {
+		t.Error("Recognizer creation failed")
+		return
+	}
+	defer recognizer.Close()
+	select {
+	case outcome := <-recognizer.RecognizeOnceAsync():
+		if outcome.Error != nil {
+			t.Error("Got an error: ", outcome.Error)
+			return
+		}
+		defer outcome.Result.Close()
+		if outcome.Result.Reason != common.RecognizedSpeech {
+			t.Error("Expected RecognizedSpeech reason, got: ", outcome.Result.Reason)
+		}
+		if outcome.Result.Text == "" {
+			t.Error("Expected non-empty recognition result")
+		}
+		t.Log("Recognized: ", outcome.Result.Text)
+	case <-time.After(5 * time.Second):
+		t.Error("Timeout waiting for recognition result.")
+	}
 }

--- a/speech/speech_synthesizer.go
+++ b/speech/speech_synthesizer.go
@@ -63,8 +63,8 @@ func NewSpeechSynthesizerFromConfig(config *SpeechConfig, audioConfig *audio.Aud
 	return newSpeechSynthesizerFromHandle(handle)
 }
 
-// NewSpeechSynthesizerFomAutoDetectSourceLangConfig creates a speech synthesizer from a speech config, auto detection source language config and audio config
-func NewSpeechSynthesizerFomAutoDetectSourceLangConfig(config *SpeechConfig, langConfig *AutoDetectSourceLanguageConfig, audioConfig *audio.AudioConfig) (*SpeechSynthesizer, error) {
+// NewSpeechSynthesizerFromAutoDetectSourceLangConfig creates a speech synthesizer from a speech config, auto detection source language config and audio config
+func NewSpeechSynthesizerFromAutoDetectSourceLangConfig(config *SpeechConfig, langConfig *AutoDetectSourceLanguageConfig, audioConfig *audio.AudioConfig) (*SpeechSynthesizer, error) {
 	var handle C.SPXHANDLE
 	if config == nil {
 		return nil, common.NewCarbonError(uintptr(C.SPXERR_INVALID_ARG))
@@ -85,6 +85,12 @@ func NewSpeechSynthesizerFomAutoDetectSourceLangConfig(config *SpeechConfig, lan
 		return nil, common.NewCarbonError(ret)
 	}
 	return newSpeechSynthesizerFromHandle(handle)
+}
+
+// NewSpeechSynthesizerFomAutoDetectSourceLangConfig is a deprecated alias for NewSpeechSynthesizerFromAutoDetectSourceLangConfig.
+// Deprecated: Use NewSpeechSynthesizerFromAutoDetectSourceLangConfig instead.
+func NewSpeechSynthesizerFomAutoDetectSourceLangConfig(config *SpeechConfig, langConfig *AutoDetectSourceLanguageConfig, audioConfig *audio.AudioConfig) (*SpeechSynthesizer, error) {
+	return NewSpeechSynthesizerFromAutoDetectSourceLangConfig(config, langConfig, audioConfig)
 }
 
 // SpeakTextAsync executes the speech synthesis on plain text, asynchronously.

--- a/speech/speech_synthesizer_test.go
+++ b/speech/speech_synthesizer_test.go
@@ -122,8 +122,8 @@ func TestSynthesizerEvents(t *testing.T) {
 		defer event.Close()
 		t.Logf("SynthesisCompleted, audio length %d", len(event.Result.AudioData))
 		checkSynthesisResult(t, &event.Result, common.SynthesizingAudioCompleted)
-		durationFromProperty := (float64)(event.Result.AudioDuration/time.Millisecond)
-		durationFromAudioBuffer := (float64)(len(event.Result.AudioData)/32)
+		durationFromProperty := (float64)(event.Result.AudioDuration / time.Millisecond)
+		durationFromAudioBuffer := (float64)(len(event.Result.AudioData) / 32)
 		if !almostEqual(durationFromProperty, durationFromAudioBuffer, 150) {
 			t.Errorf("Synthesis duration incorrect (%.2f vs %.2f)", durationFromProperty, durationFromAudioBuffer)
 		}
@@ -461,7 +461,7 @@ func TestSynthesisWithLanguageAutoDetection(t *testing.T) {
 		t.Error("Got an error: ", err)
 	}
 	defer languageConfig.Close()
-	synthesizer, err := NewSpeechSynthesizerFomAutoDetectSourceLangConfig(config, languageConfig, nil)
+	synthesizer, err := NewSpeechSynthesizerFromAutoDetectSourceLangConfig(config, languageConfig, nil)
 	if err != nil {
 		t.Error("Got an error: ", err)
 	}


### PR DESCRIPTION
# Fix AutoDetectSourceLangConfig API Misspellings

## Problem

Two public API constructors in the Go Speech SDK have a spelling error — `Fom` instead of `From`:

| Misspelled Name | Corrected Name |
|---|---|
| `NewSpeechRecognizerFomAutoDetectSourceLangConfig` | `NewSpeechRecognizerFromAutoDetectSourceLangConfig` |
| `NewSpeechSynthesizerFomAutoDetectSourceLangConfig` | `NewSpeechSynthesizerFromAutoDetectSourceLangConfig` |

These functions also lacked tests (recognizer) and samples (both).

## Changes

### API Fix (backward-compatible)

- **speech/speech_recognizer.go** — Renamed `NewSpeechRecognizerFomAutoDetectSourceLangConfig` to `NewSpeechRecognizerFromAutoDetectSourceLangConfig`. Added a deprecated alias under the old name that delegates to the corrected function.
- **speech/speech_synthesizer.go** — Renamed `NewSpeechSynthesizerFomAutoDetectSourceLangConfig` to `NewSpeechSynthesizerFromAutoDetectSourceLangConfig`. Added a deprecated alias under the old name that delegates to the corrected function.

### New Tests

- **speech/speech_recognizer_test.go** — Added `TestRecognitionWithLanguageAutoDetection`: creates a recognizer via `NewSpeechRecognizerFromAutoDetectSourceLangConfig` with `en-US`/`de-DE`, recognizes from a WAV file, validates the result reason and text.
- **speech/speech_synthesizer_test.go** — Updated existing `TestSynthesisWithLanguageAutoDetection` to use the corrected API name. Minor formatting fix (operator spacing).

### New Samples

- **samples/recognizer/auto_detect.go** — New sample `RecognizeOnceFromAutoDetectSourceLangConfig` demonstrating speech recognition with auto-detect source language.
- **samples/synthesizer/auto_detect.go** — New sample `SynthesisFromAutoDetectSourceLangConfig` demonstrating speech synthesis with auto-detect source language (open range).
- **samples/main.go** — Registered both new samples in the sample map.

## Backward Compatibility

The old misspelled function names are preserved as deprecated aliases. Existing code using `NewSpeechRecognizerFomAutoDetectSourceLangConfig` or `NewSpeechSynthesizerFomAutoDetectSourceLangConfig` will continue to compile and work. The `// Deprecated:` comment will surface warnings in IDEs and `go doc`.

## How to Use

```go
langConfig, _ := speech.NewAutoDetectSourceLanguageConfigFromLanguages([]string{"en-US", "de-DE"})
recognizer, _ := speech.NewSpeechRecognizerFromAutoDetectSourceLangConfig(cfg, langConfig, audioCfg)
// Deprecated alias (still works, but use the new name):
recognizer, _ := speech.NewSpeechRecognizerFomAutoDetectSourceLangConfig(cfg, langConfig, audioCfg)
```

```go
langConfig, _ := speech.NewAutoDetectSourceLanguageConfigFromOpenRange()
synthesizer, _ := speech.NewSpeechSynthesizerFromAutoDetectSourceLangConfig(cfg, langConfig, nil)
// Deprecated alias (still works, but use the new name):
synthesizer, _ := speech.NewSpeechSynthesizerFomAutoDetectSourceLangConfig(cfg, langConfig, nil)
```

> The `// Deprecated:` comment is present on the old names, so `go doc` and IDEs will surface the warning automatically.

## Testing

- `go build ./...` — ✅ PASS
- `go vet ./...` — ⚠️ known upstream warnings (unsafe.Pointer & unkeyed OperationOutcome literals). Unrelated to this change.
- `go test ./speech/ -run "TestRecognitionWithLanguageAutoDetection" -v -timeout 30s` — ✅ PASS (0.65s)
- `go test ./speech/ -run "TestSynthesisWithLanguageAutoDetection" -v -timeout 30s` — ✅ PASS (0.42s)

> Tests require `SPEECH_SUBSCRIPTION_KEY` and `SPEECH_SUBSCRIPTION_REGION` env vars and the `test_files/turn_on_the_lamp.wav` asset.
