### PR TITLE
fix memory leak in TranslationSynthesisEventArgs handle lifetime

### DIFF
--- a/speech/translation_recognition_result.go
+++ b/speech/translation_recognition_result.go
@@ -185,11 +185,23 @@ func NewTranslationRecognitionCanceledEventArgsFromHandle(handle common.SPXHandl
 // TranslationSynthesisEventArgs represents the event arguments for a translation synthesis event.
 type TranslationSynthesisEventArgs struct {
 	SessionEventArgs
-	Result *TranslationSynthesisResult
+	Result       *TranslationSynthesisResult
+	resultHandle C.SPXRESULTHANDLE
+}
+
+// Close releases the underlying resources.
+func (event TranslationSynthesisEventArgs) Close() {
+	C.recognizer_result_handle_release(event.resultHandle)
+	event.SessionEventArgs.Close()
 }
 
 // NewTranslationSynthesisEventArgsFromHandle creates a TranslationSynthesisEventArgs from a handle.
 func NewTranslationSynthesisEventArgsFromHandle(handle common.SPXHandle) (*TranslationSynthesisEventArgs, error) {
+	base, err := NewSessionEventArgsFromHandle(handle)
+	if err != nil {
+		return nil, err
+	}
+
 	var resultHandle C.SPXRESULTHANDLE
 	ret := uintptr(C.recognizer_recognition_event_get_result(uintptr2handle(handle), &resultHandle))
 	if ret != C.SPX_NOERROR {
@@ -198,10 +210,15 @@ func NewTranslationSynthesisEventArgsFromHandle(handle common.SPXHandle) (*Trans
 
 	result, err := NewTranslationSynthesisResultFromHandle(handle2uintptr(resultHandle))
 	if err != nil {
+		C.recognizer_result_handle_release(resultHandle)
 		return nil, err
 	}
 
-	return &TranslationSynthesisEventArgs{Result: result}, nil
+	event := new(TranslationSynthesisEventArgs)
+	event.SessionEventArgs = *base
+	event.Result = result
+	event.resultHandle = resultHandle
+	return event, nil
 }
 
 // Event handler types


### PR DESCRIPTION
## The problem

`NewTranslationSynthesisEventArgsFromHandle` never initializes the embedded `SessionEventArgs` with the event handle. This means calling `Close()` on a `TranslationSynthesisEventArgs` calls `recognizer_event_handle_release` with a zero handle, which does nothing. The event handle leaks on every Synthesizing callback.

The function also obtains a result handle via `recognizer_recognition_event_get_result` but never stores it. `TranslationSynthesisResult` has no handle field and no `Close()` method, so the result handle leaks too.

Compare with `NewTranslationRecognitionEventArgsFromHandle`, which correctly initializes the base struct by calling `NewRecognitionEventArgsFromHandle`. The synthesis path skips this step entirely and returns a bare struct literal:

```go
// current (broken)
return &TranslationSynthesisEventArgs{Result: result}, nil
```

The C++ wrapper handles this correctly in `speechapi_cxx_translation_eventargs.h`, where it retains and releases the event handle in the constructor and destructor.

## The fix

Two changes in `NewTranslationSynthesisEventArgsFromHandle`:

1. Initialize `SessionEventArgs` by calling `NewSessionEventArgsFromHandle(handle)`, so `Close()` actually releases the event handle.
2. Store the result handle in a new field and add a `Close()` method that releases both the result handle and the event handle.

## Related issues

- #150 reports the same symptom (CGo memory growing, Go heap flat) for SpeechSynthesizer
- #125 fixes callback map cleanup but doesn't touch this code path