### PR TITLE
Add embedded (offline) speech support

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  CARBON_VERSION: "1.43.0"
+  CARBON_VERSION: "1.50.0"
 
 jobs:
   linux:
@@ -43,6 +43,13 @@ jobs:
         rm SpeechSDK-Linux-$CARBON_VERSION.tar.gz
         ln -s SpeechSDK-Linux-$CARBON_VERSION current
         popd
+    # Embedded (offline) speech: the embedded_speech_config_* / speech_recognition_model_* C
+    # symbols live in the core library and their headers ship in the standard SDK tarball above,
+    # so the bindings compile and link without any extra steps. Actually running embedded
+    # recognition/synthesis additionally requires the embedded runtime extensions
+    # (libMicrosoft.CognitiveServices.Speech.extension.embedded.sr/.tts + onnxruntime) staged next
+    # to the core library, plus licensed on-device models/voices. Those are a Limited Access
+    # feature and are not exercised by CI.
     - name: Get Carbon Dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,10 +4,6 @@ on:
     branches:
       - master
       - main
-  pull_request:
-    branches:
-      - master
-      - main
   workflow_dispatch:
 
 env:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - master
       - main
+  pull_request:
+    branches:
+      - master
+      - main
   workflow_dispatch:
 
 env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
       - main
   pull_request:
 env:
-  CARBON_VERSION: "1.48.2"
+  CARBON_VERSION: "1.50.0"
 jobs:
   golangci:
     name: lint

--- a/README.md
+++ b/README.md
@@ -12,6 +12,94 @@ Get started with [text-to-speech sample for Go](https://docs.microsoft.com/azure
 
 This project requires Go 1.13
 
+# Embedded (offline) speech
+
+The SDK also supports embedded (offline) speech recognition, synthesis and translation, which run fully
+on-device without using the cloud Speech service. Use `speech.NewEmbeddedSpeechConfigFromPath` (or
+`NewEmbeddedSpeechConfigFromPaths`) to point at the directory that contains your offline models and
+voices, then reuse the standard recognizer, synthesizer and translation recognizer factories:
+
+```go
+config, err := speech.NewEmbeddedSpeechConfigFromPath("/path/to/models")
+if err != nil {
+    // handle error
+}
+defer config.Close()
+
+// Select a recognition model and its license text.
+config.SetSpeechRecognitionModel("en-US model name", os.Getenv("EMBEDDED_SPEECH_MODEL_LICENSE"))
+
+// The embedded config wraps a regular SpeechConfig, so pass GetSpeechConfig() to the existing factory.
+recognizer, err := speech.NewSpeechRecognizerFromConfig(config.GetSpeechConfig(), audioConfig)
+
+// For embedded translation, select a translation model and use the dedicated factory.
+config.SetSpeechTranslationModel("translation model name", os.Getenv("EMBEDDED_SPEECH_MODEL_LICENSE"))
+translationRecognizer, err := speech.NewTranslationRecognizerFromEmbeddedConfig(config, audioConfig)
+```
+
+Embedded speech has additional runtime requirements:
+
+- The embedded native runtime extensions (for example
+  `libMicrosoft.CognitiveServices.Speech.extension.embedded.sr`/`.tts` and their `onnxruntime`
+  dependency) must be present next to the core Speech SDK library on the load path.
+- Licensed speech recognition models, synthesis voices and/or translation models must be installed on
+  the device and passed to the config via the model/voice path.
+- Embedded speech is a Limited Access feature that requires approval from Microsoft.
+
+## Discovering installed models
+
+If you don't know the exact model or voice name, enumerate what is installed under the configured
+path and use one of the returned names:
+
+```go
+models, err := config.GetSpeechRecognitionModels() // or GetSpeechTranslationModels()
+if err != nil {
+    // handle error
+}
+for _, model := range models {
+    fmt.Printf("%s (locales: %v)\n", model.Name(), model.Locales())
+    model.Close()
+}
+config.SetSpeechRecognitionModel(models[0].Name(), os.Getenv("EMBEDDED_SPEECH_MODEL_LICENSE"))
+```
+
+## Building and running
+
+Embedded speech uses cgo, so the Go toolchain must be told where the native Speech SDK headers and
+libraries live at build time, and the shared libraries must be discoverable at run time. On Linux/x64,
+point `CGO_CFLAGS`/`CGO_LDFLAGS` at the embedded Speech SDK package and add its `lib` folder to the
+loader path:
+
+```bash
+export SPEECHSDK_ROOT=/path/to/SpeechSDK-Embedded-Linux
+export CGO_CFLAGS="-I$SPEECHSDK_ROOT/include/c_api"
+export CGO_LDFLAGS="-L$SPEECHSDK_ROOT/lib/x64 -lMicrosoft.CognitiveServices.Speech.core"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SPEECHSDK_ROOT/lib/x64"
+
+go build ./...
+```
+
+The [samples/embedded](samples/embedded) package provides runnable functions. Using the sample runner
+in [samples](samples), the arguments are `(modelPath, modelOrVoiceName, wavFile)` followed by the
+sample name:
+
+```bash
+# Speech-to-text
+go run . /path/to/models "en-US model name" input.wav embedded:RecognizeOnceFromWavFile
+
+# Speech translation
+go run . /path/to/translation/models "translation model name" input.wav embedded:TranslateOnceFromWavFile
+
+# Text-to-speech
+go run . /path/to/voices "en-US voice name" output.wav embedded:SynthesisToWavFile
+```
+
+The model/voice license text is read from the `EMBEDDED_SPEECH_MODEL_LICENSE` environment variable
+(the same license applies to recognition, synthesis and translation) so it is not passed on the command line.
+
+See the [embedded samples guide](samples/embedded/README.md) for prerequisites, native library setup,
+model/voice installation, build flags and a walkthrough of each sample.
+
 # Reference
 
 Reference documentation for these packages is available at http://aka.ms/csspeech/goref

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -23,7 +23,7 @@ schedules:
 pool:
   vmImage: ubuntu-latest
 variables:
-  CARBON_VERSION: "1.48.2"
+  CARBON_VERSION: "1.50.0"
 
 steps:
 - task: GoTool@0

--- a/common/property_id.go
+++ b/common/property_id.go
@@ -87,6 +87,19 @@ const (
 	// SpeechServiceConnectionTranslationFeatures is the translation features. For internal use.
 	SpeechServiceConnectionTranslationFeatures PropertyID = 2002
 
+	// SpeechTranslationModelName is the name of the model to be used for embedded (offline) speech translation.
+	// Under normal circumstances, you shouldn't use this property directly.
+	// Instead, use EmbeddedSpeechConfig.SetSpeechTranslationModel.
+	// Added in version 1.19.0
+	SpeechTranslationModelName PropertyID = 13100
+
+	// SpeechTranslationModelKey is the decryption key of the model to be used for embedded (offline) speech
+	// translation.
+	// Under normal circumstances, you shouldn't use this property directly.
+	// Instead, use EmbeddedSpeechConfig.SetSpeechTranslationModel.
+	// Added in version 1.19.0
+	SpeechTranslationModelKey PropertyID = 13101
+
 	// SpeechServiceConnectionRecoMode is the Cognitive Services Speech Service recognition mode. Can be "INTERACTIVE",
 	// "CONVERSATION" or "DICTATION".
 	// This property is intended to be read-only. The SDK is using it internally.
@@ -107,6 +120,19 @@ const (
 	// to the service as URL query parameters.
 	SpeechServiceConnectionUserDefinedQueryParameters PropertyID = 3003
 
+	// SpeechServiceConnectionRecoModelName is the name of the model to be used for embedded (offline) speech recognition.
+	// Under normal circumstances, you shouldn't use this property directly.
+	// Instead, use EmbeddedSpeechConfig.SetSpeechRecognitionModel.
+	// Added in version 1.19.0
+	SpeechServiceConnectionRecoModelName PropertyID = 3005
+
+	// SpeechServiceConnectionRecoModelKey is the decryption key of the model to be used for embedded (offline) speech
+	// recognition.
+	// Under normal circumstances, you shouldn't use this property directly.
+	// Instead, use EmbeddedSpeechConfig.SetSpeechRecognitionModel.
+	// Added in version 1.19.0
+	SpeechServiceConnectionRecoModelKey PropertyID = 3006
+
 	// SpeechServiceConnectionSynthLanguage is the spoken language to be synthesized (e.g. en-US)
 	SpeechServiceConnectionSynthLanguage PropertyID = 3100
 
@@ -123,6 +149,20 @@ const (
 	// and decode it. You can set this property to "false" to use raw pcm format for transmission on wire.
 	// Added in version 1.17.0
 	SpeechServiceConnectionSynthEnableCompressedAudioTransmission PropertyID = 3103
+
+	// SpeechServiceConnectionSynthOfflineVoice is the name of the offline TTS voice to be used for embedded
+	// (offline) speech synthesis.
+	// Under normal circumstances, you shouldn't use this property directly.
+	// Instead, use EmbeddedSpeechConfig.SetSpeechSynthesisVoice.
+	// Added in version 1.19.0
+	SpeechServiceConnectionSynthOfflineVoice PropertyID = 3113
+
+	// SpeechServiceConnectionSynthModelKey is the decryption key of the voice to be used for embedded (offline)
+	// speech synthesis.
+	// Under normal circumstances, you shouldn't use this property directly.
+	// Instead, use EmbeddedSpeechConfig.SetSpeechSynthesisVoice.
+	// Added in version 1.19.0
+	SpeechServiceConnectionSynthModelKey PropertyID = 3114
 
 	// SpeechServiceConnectionInitialSilenceTimeoutMs is the initial silence timeout value (in milliseconds) used by the
 	// service.
@@ -354,4 +394,16 @@ const (
 	// DataBufferUserID is the user id associated to data buffer written by client when using Pull/Push audio
 	// input streams.
 	DataBufferUserID PropertyID = 11002
+
+	// KeywordRecognitionModelName is the name of the model to be used for keyword recognition.
+	// Under normal circumstances, you shouldn't use this property directly.
+	// Instead, use EmbeddedSpeechConfig.SetKeywordRecognitionModel.
+	// Added in version 1.19.0
+	KeywordRecognitionModelName PropertyID = 13200
+
+	// KeywordRecognitionModelKey is the decryption key of the model to be used for keyword recognition.
+	// Under normal circumstances, you shouldn't use this property directly.
+	// Instead, use EmbeddedSpeechConfig.SetKeywordRecognitionModel.
+	// Added in version 1.19.0
+	KeywordRecognitionModelKey PropertyID = 13201
 )

--- a/common/property_id.go
+++ b/common/property_id.go
@@ -90,14 +90,12 @@ const (
 	// SpeechTranslationModelName is the name of the model to be used for embedded (offline) speech translation.
 	// Under normal circumstances, you shouldn't use this property directly.
 	// Instead, use EmbeddedSpeechConfig.SetSpeechTranslationModel.
-	// Added in version 1.19.0
 	SpeechTranslationModelName PropertyID = 13100
 
 	// SpeechTranslationModelKey is the decryption key of the model to be used for embedded (offline) speech
 	// translation.
 	// Under normal circumstances, you shouldn't use this property directly.
 	// Instead, use EmbeddedSpeechConfig.SetSpeechTranslationModel.
-	// Added in version 1.19.0
 	SpeechTranslationModelKey PropertyID = 13101
 
 	// SpeechServiceConnectionRecoMode is the Cognitive Services Speech Service recognition mode. Can be "INTERACTIVE",
@@ -123,14 +121,12 @@ const (
 	// SpeechServiceConnectionRecoModelName is the name of the model to be used for embedded (offline) speech recognition.
 	// Under normal circumstances, you shouldn't use this property directly.
 	// Instead, use EmbeddedSpeechConfig.SetSpeechRecognitionModel.
-	// Added in version 1.19.0
 	SpeechServiceConnectionRecoModelName PropertyID = 3005
 
 	// SpeechServiceConnectionRecoModelKey is the decryption key of the model to be used for embedded (offline) speech
 	// recognition.
 	// Under normal circumstances, you shouldn't use this property directly.
 	// Instead, use EmbeddedSpeechConfig.SetSpeechRecognitionModel.
-	// Added in version 1.19.0
 	SpeechServiceConnectionRecoModelKey PropertyID = 3006
 
 	// SpeechServiceConnectionSynthLanguage is the spoken language to be synthesized (e.g. en-US)
@@ -154,14 +150,12 @@ const (
 	// (offline) speech synthesis.
 	// Under normal circumstances, you shouldn't use this property directly.
 	// Instead, use EmbeddedSpeechConfig.SetSpeechSynthesisVoice.
-	// Added in version 1.19.0
 	SpeechServiceConnectionSynthOfflineVoice PropertyID = 3113
 
 	// SpeechServiceConnectionSynthModelKey is the decryption key of the voice to be used for embedded (offline)
 	// speech synthesis.
 	// Under normal circumstances, you shouldn't use this property directly.
 	// Instead, use EmbeddedSpeechConfig.SetSpeechSynthesisVoice.
-	// Added in version 1.19.0
 	SpeechServiceConnectionSynthModelKey PropertyID = 3114
 
 	// SpeechServiceConnectionInitialSilenceTimeoutMs is the initial silence timeout value (in milliseconds) used by the
@@ -398,12 +392,10 @@ const (
 	// KeywordRecognitionModelName is the name of the model to be used for keyword recognition.
 	// Under normal circumstances, you shouldn't use this property directly.
 	// Instead, use EmbeddedSpeechConfig.SetKeywordRecognitionModel.
-	// Added in version 1.19.0
 	KeywordRecognitionModelName PropertyID = 13200
 
 	// KeywordRecognitionModelKey is the decryption key of the model to be used for keyword recognition.
 	// Under normal circumstances, you shouldn't use this property directly.
 	// Instead, use EmbeddedSpeechConfig.SetKeywordRecognitionModel.
-	// Added in version 1.19.0
 	KeywordRecognitionModelKey PropertyID = 13201
 )

--- a/samples/embedded/README.md
+++ b/samples/embedded/README.md
@@ -1,0 +1,141 @@
+# Embedded (offline) speech samples for Go
+
+These samples show how to use the Microsoft Cognitive Services Speech SDK for Go to run speech
+**recognition**, **synthesis** and **translation** fully on-device, without connecting to the cloud
+Speech service.
+
+| Sample | Function | Scenario |
+| ------ | -------- | -------- |
+| [recognizer.go](recognizer.go) | `RecognizeOnceFromWavFile` | Single-shot speech-to-text from a WAV file. |
+| [continuous.go](continuous.go) | `RecognizeContinuousFromWavFile` | Continuous speech-to-text from a WAV file. |
+| [synthesizer.go](synthesizer.go) | `SynthesisToWavFile` | Text-to-speech to a WAV file. |
+| [translation.go](translation.go) | `TranslateOnceFromWavFile` | Single-shot speech translation from a WAV file. |
+
+## Prerequisites
+
+Embedded speech is a **Limited Access** feature. Before you can build and run these samples you need:
+
+1. **Approval for embedded speech.** Access to the embedded runtime and to models/voices requires
+   registration and approval from Microsoft. See
+   [Embedded Speech](https://learn.microsoft.com/azure/ai-services/speech-service/embedded-speech).
+2. **The embedded native Speech SDK package** for your platform (contains the core library *and* the
+   embedded runtime extensions). See [Native libraries](#native-libraries).
+3. **Licensed models and/or voices** installed on the device. See [Models and voices](#models-and-voices).
+4. A working **cgo** toolchain (a C compiler such as `gcc`/`clang`), because the SDK is a cgo binding.
+5. **Go 1.13** or later.
+
+## Native libraries
+
+Embedded speech needs the on-device runtime extensions that are **not** part of the standard
+(cloud-only) Speech SDK package. Download the **embedded** Speech SDK package. It is a superset of the
+standard package: it contains everything the standard package has, plus the offline runtimes:
+
+- `libMicrosoft.CognitiveServices.Speech.core` — the core library.
+- `...extension.embedded.sr` and `...extension.embedded.sr.runtime` — offline recognition/translation.
+- `...extension.embedded.tts` and `...extension.embedded.tts.runtime` — offline synthesis.
+- `...extension.onnxruntime` — neural inference used by the offline runtimes.
+
+Because the embedded package is a superset, an embedded user only needs to download the **embedded**
+package — not both the standard and embedded packages.
+
+> The native package ships the **engine only**. The actual models and voices are separate, licensed
+> assets (see below).
+
+## Models and voices
+
+The speech recognition models, translation models and synthesis voices are **not** included in the
+native SDK package. They are separately licensed assets that you obtain through the Limited Access
+program and install into a directory on the device. Each sample takes the path to that directory as
+its first argument.
+
+If you do not know the exact model or voice name, the samples that recognize/translate call
+`EmbeddedSpeechConfig.GetSpeechRecognitionModels` / `GetSpeechTranslationModels` and print the
+installed names and locales at startup. You can also enumerate them yourself:
+
+```go
+config, _ := speech.NewEmbeddedSpeechConfigFromPath("/path/to/models")
+defer config.Close()
+
+models, _ := config.GetSpeechRecognitionModels() // or GetSpeechTranslationModels()
+for _, model := range models {
+    fmt.Printf("%s (locales: %v)\n", model.Name(), model.Locales())
+    model.Close()
+}
+```
+
+## Environment variables
+
+The model / voice **license text** is read from an environment variable so it does not have to be
+passed on the command line. The same license applies to recognition, synthesis and translation:
+
+| Variable | Description |
+| -------- | ----------- |
+| `EMBEDDED_SPEECH_MODEL_LICENSE` | License text (or the path to it) for the models and voices you use. |
+
+The model / voice **path** and **name** are passed as command-line arguments to the sample runner
+(see [Running the samples](#running-the-samples)).
+
+## Building
+
+The SDK is a cgo binding, so the Go toolchain must know where the native headers and libraries are at
+build time, and the shared libraries must be discoverable at run time. On Linux, point
+`CGO_CFLAGS` / `CGO_LDFLAGS` at the embedded Speech SDK package and add its `lib` folder for your
+architecture to the loader path. For x64:
+
+```bash
+export SPEECHSDK_ROOT=/path/to/SpeechSDK-Embedded-Linux
+export CGO_CFLAGS="-I$SPEECHSDK_ROOT/include/c_api"
+export CGO_LDFLAGS="-L$SPEECHSDK_ROOT/lib/x64 -lMicrosoft.CognitiveServices.Speech.core"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SPEECHSDK_ROOT/lib/x64"
+
+go build ./...
+```
+
+For 64-bit Arm use `lib/arm64`; for 32-bit Arm use `lib/arm32`.
+
+## Running the samples
+
+The samples are invoked through the shared sample runner in [../main.go](../main.go). The runner takes
+four positional arguments; for the embedded samples the first three are repurposed as
+`(modelPath, modelOrVoiceName, wavFile)` and the **sample name comes last**:
+
+```bash
+# Provide the license once for the whole session.
+export EMBEDDED_SPEECH_MODEL_LICENSE="<your model/voice license text>"
+
+# Speech-to-text (single shot)
+go run . /path/to/models "en-US recognition model name" input.wav embedded:RecognizeOnceFromWavFile
+
+# Speech-to-text (continuous)
+go run . /path/to/models "en-US recognition model name" input.wav embedded:RecognizeContinuousFromWavFile
+
+# Speech translation (single shot)
+go run . /path/to/translation/models "translation model name" input.wav embedded:TranslateOnceFromWavFile
+
+# Text-to-speech (writes a WAV file)
+go run . /path/to/voices "en-US voice name" output.wav embedded:SynthesisToWavFile
+```
+
+The input WAV files for recognition and translation should be 16 kHz (or 8 kHz) mono PCM. The
+synthesis sample writes a 24 kHz 16-bit mono PCM WAV file.
+
+## Troubleshooting
+
+- **`SPXERR_...` / "model load error" at recognition or synthesis start.** The model or voice was not
+  found at the configured path, or the name does not match an installed model/voice. Let the sample
+  print the installed models, or enumerate them as shown in [Models and voices](#models-and-voices),
+  and pass an exact `Name()` value.
+- **Link errors for `Microsoft.CognitiveServices.Speech.core` at build time.** `CGO_LDFLAGS` is not
+  pointing at the `lib/<arch>` folder of the **embedded** package, or you are using the standard
+  (cloud-only) package.
+- **`error while loading shared libraries` at run time.** The `lib/<arch>` folder is not on
+  `LD_LIBRARY_PATH`, so the loader cannot find the core library or the embedded runtime extensions.
+- **Recognition/synthesis works online but not offline.** You are linking against the standard package,
+  which does not contain the embedded runtime extensions. Use the embedded package (see
+  [Native libraries](#native-libraries)).
+
+## See also
+
+- Package documentation: [doc.go](doc.go)
+- Embedded speech section in the repository [README](../../README.md#embedded-offline-speech)
+- [Embedded Speech overview](https://learn.microsoft.com/azure/ai-services/speech-service/embedded-speech)

--- a/samples/embedded/continuous.go
+++ b/samples/embedded/continuous.go
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+
+package embedded
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/audio"
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/common"
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/speech"
+)
+
+// RecognizeContinuousFromWavFile performs continuous embedded (offline) recognition from a WAV file.
+//
+// Arguments:
+//   - modelPath: path to a directory that contains offline speech recognition models.
+//   - modelName: name of the recognition model to use (see EmbeddedSpeechConfig.GetSpeechRecognitionModels).
+//   - file:      path to the input WAV file.
+//
+// The model license text is read from the EMBEDDED_SPEECH_MODEL_LICENSE environment variable.
+func RecognizeContinuousFromWavFile(modelPath string, modelName string, file string) {
+	audioConfig, err := audio.NewAudioConfigFromWavFileInput(file)
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer audioConfig.Close()
+
+	config, err := speech.NewEmbeddedSpeechConfigFromPath(modelPath)
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer config.Close()
+
+	license := os.Getenv("EMBEDDED_SPEECH_MODEL_LICENSE")
+	if err = config.SetSpeechRecognitionModel(modelName, license); err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+
+	// The embedded config wraps a regular SpeechConfig, so reuse the standard recognizer factory.
+	speechRecognizer, err := speech.NewSpeechRecognizerFromConfig(config.GetSpeechConfig(), audioConfig)
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer speechRecognizer.Close()
+
+	done := make(chan struct{})
+	speechRecognizer.SessionStarted(func(event speech.SessionEventArgs) {
+		defer event.Close()
+		fmt.Println("Session Started (ID=", event.SessionID, ")")
+	})
+	speechRecognizer.SessionStopped(func(event speech.SessionEventArgs) {
+		defer event.Close()
+		fmt.Println("Session Stopped (ID=", event.SessionID, ")")
+		close(done)
+	})
+	speechRecognizer.Recognizing(func(event speech.SpeechRecognitionEventArgs) {
+		defer event.Close()
+		fmt.Println("Recognizing:", event.Result.Text)
+	})
+	speechRecognizer.Recognized(func(event speech.SpeechRecognitionEventArgs) {
+		defer event.Close()
+		fmt.Println("Recognized:", event.Result.Text)
+	})
+	speechRecognizer.Canceled(func(event speech.SpeechRecognitionCanceledEventArgs) {
+		defer event.Close()
+		if event.Reason == common.EndOfStream {
+			fmt.Println("Reached the end of the audio stream.")
+			return
+		}
+		fmt.Printf("Canceled: reason=%v, error=%v, details=%s\n", event.Reason, event.ErrorCode, event.ErrorDetails)
+	})
+
+	if err = <-speechRecognizer.StartContinuousRecognitionAsync(); err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer speechRecognizer.StopContinuousRecognitionAsync()
+
+	// Wait for the session to stop (end of the WAV file) or time out.
+	select {
+	case <-done:
+	case <-time.After(60 * time.Second):
+		fmt.Println("Timed out")
+	}
+}

--- a/samples/embedded/doc.go
+++ b/samples/embedded/doc.go
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+
+// Package embedded demonstrates embedded (offline) speech recognition, synthesis and translation.
+//
+// It provides the following samples:
+//   - RecognizeOnceFromWavFile:       single-shot speech recognition from a WAV file.
+//   - RecognizeContinuousFromWavFile: continuous speech recognition from a WAV file.
+//   - SynthesisToWavFile:             speech synthesis to a WAV file.
+//   - TranslateOnceFromWavFile:       single-shot speech translation from a WAV file.
+//
+// Embedded speech runs fully on-device and does not use the cloud Speech service. It requires:
+//   - The embedded native runtime extensions to be present next to the core Speech SDK library.
+//   - Licensed speech recognition models, synthesis voices and/or translation models installed on the device.
+//
+// The three positional command line arguments are repurposed for the embedded samples as
+// (modelPath, modelOrVoiceName, file). The model/voice license text is read from an environment
+// variable so it does not have to be passed on the command line:
+//   - EMBEDDED_SPEECH_MODEL_LICENSE for speech recognition models, synthesis voices and translation models.
+//     The same license applies to embedded speech recognition, synthesis and translation.
+//
+// If you do not know the exact model or voice name, call EmbeddedSpeechConfig.GetSpeechRecognitionModels
+// or GetSpeechTranslationModels to enumerate what is installed under modelPath, then pass one of the
+// returned Name() values.
+package embedded

--- a/samples/embedded/recognizer.go
+++ b/samples/embedded/recognizer.go
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+
+package embedded
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/audio"
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/speech"
+)
+
+// RecognizeOnceFromWavFile performs a single embedded (offline) recognition from a WAV file.
+//
+// Arguments:
+//   - modelPath: path to a directory that contains offline speech recognition models.
+//   - modelName: name of the recognition model to use (see EmbeddedSpeechConfig.GetSpeechRecognitionModels).
+//   - file:      path to the input WAV file.
+//
+// The model license text is read from the EMBEDDED_SPEECH_MODEL_LICENSE environment variable.
+func RecognizeOnceFromWavFile(modelPath string, modelName string, file string) {
+	audioConfig, err := audio.NewAudioConfigFromWavFileInput(file)
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer audioConfig.Close()
+
+	config, err := speech.NewEmbeddedSpeechConfigFromPath(modelPath)
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer config.Close()
+
+	// List the recognition models available in the configured path.
+	models, err := config.GetSpeechRecognitionModels()
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	for _, model := range models {
+		fmt.Printf("Found model: %s (locales: %v)\n", model.Name(), model.Locales())
+		model.Close()
+	}
+
+	license := os.Getenv("EMBEDDED_SPEECH_MODEL_LICENSE")
+	if err = config.SetSpeechRecognitionModel(modelName, license); err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+
+	// The embedded config wraps a regular SpeechConfig, so reuse the standard recognizer factory.
+	speechRecognizer, err := speech.NewSpeechRecognizerFromConfig(config.GetSpeechConfig(), audioConfig)
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer speechRecognizer.Close()
+
+	speechRecognizer.SessionStarted(func(event speech.SessionEventArgs) {
+		defer event.Close()
+		fmt.Println("Session Started (ID=", event.SessionID, ")")
+	})
+	speechRecognizer.SessionStopped(func(event speech.SessionEventArgs) {
+		defer event.Close()
+		fmt.Println("Session Stopped (ID=", event.SessionID, ")")
+	})
+
+	task := speechRecognizer.RecognizeOnceAsync()
+	var outcome speech.SpeechRecognitionOutcome
+	select {
+	case outcome = <-task:
+	case <-time.After(15 * time.Second):
+		fmt.Println("Timed out")
+		return
+	}
+	defer outcome.Close()
+	if outcome.Error != nil {
+		fmt.Println("Got an error: ", outcome.Error)
+		return
+	}
+	fmt.Println("Got a recognition!")
+	fmt.Println(outcome.Result.Text)
+}

--- a/samples/embedded/synthesizer.go
+++ b/samples/embedded/synthesizer.go
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+
+package embedded
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/audio"
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/common"
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/speech"
+)
+
+// SynthesisToWavFile performs embedded (offline) speech synthesis to a WAV file.
+//
+// Arguments:
+//   - modelPath: path to a directory that contains offline synthesis voices.
+//   - voiceName: name of the synthesis voice to use.
+//   - file:      path to the output WAV file.
+//
+// The voice license text is read from the EMBEDDED_SPEECH_MODEL_LICENSE environment variable.
+func SynthesisToWavFile(modelPath string, voiceName string, file string) {
+	audioConfig, err := audio.NewAudioConfigFromWavFileOutput(file)
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer audioConfig.Close()
+
+	config, err := speech.NewEmbeddedSpeechConfigFromPath(modelPath)
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer config.Close()
+
+	license := os.Getenv("EMBEDDED_SPEECH_MODEL_LICENSE")
+	if err = config.SetSpeechSynthesisVoice(voiceName, license); err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	// Offline synthesis produces raw PCM audio.
+	if err = config.SetSpeechSynthesisOutputFormat(common.Riff24Khz16BitMonoPcm); err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+
+	// The embedded config wraps a regular SpeechConfig, so reuse the standard synthesizer factory.
+	speechSynthesizer, err := speech.NewSpeechSynthesizerFromConfig(config.GetSpeechConfig(), audioConfig)
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer speechSynthesizer.Close()
+
+	speechSynthesizer.SynthesisStarted(func(event speech.SpeechSynthesisEventArgs) {
+		defer event.Close()
+		fmt.Println("Synthesis started.")
+	})
+	speechSynthesizer.SynthesisCompleted(func(event speech.SpeechSynthesisEventArgs) {
+		defer event.Close()
+		fmt.Printf("Synthesized, audio length %d.\n", len(event.Result.AudioData))
+	})
+	speechSynthesizer.SynthesisCanceled(func(event speech.SpeechSynthesisEventArgs) {
+		defer event.Close()
+		fmt.Println("Received a cancellation.")
+	})
+
+	task := speechSynthesizer.SpeakTextAsync("Hello from embedded speech synthesis.")
+	var outcome speech.SpeechSynthesisOutcome
+	select {
+	case outcome = <-task:
+	case <-time.After(60 * time.Second):
+		fmt.Println("Timed out")
+		return
+	}
+	defer outcome.Close()
+	if outcome.Error != nil {
+		fmt.Println("Got an error: ", outcome.Error)
+		return
+	}
+	if outcome.Result.Reason != common.SynthesizingAudioCompleted {
+		cancellation, _ := speech.NewCancellationDetailsFromSpeechSynthesisResult(outcome.Result)
+		fmt.Printf("Synthesis canceled: reason=%v.\n", cancellation.Reason)
+		if cancellation.Reason == common.Error {
+			fmt.Printf("Synthesis canceled: error=%v, details=%s\n", cancellation.ErrorCode, cancellation.ErrorDetails)
+		}
+		return
+	}
+	fmt.Printf("Synthesis finished, audio written to %s.\n", file)
+}

--- a/samples/embedded/translation.go
+++ b/samples/embedded/translation.go
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+
+package embedded
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/audio"
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/speech"
+)
+
+// TranslateOnceFromWavFile performs a single embedded (offline) speech translation from a WAV file.
+//
+// Arguments:
+//   - modelPath: path to a directory that contains offline speech translation models.
+//   - modelName: name of the translation model to use (see EmbeddedSpeechConfig.GetSpeechTranslationModels).
+//   - file:      path to the input WAV file.
+//
+// The model license text is read from the EMBEDDED_SPEECH_MODEL_LICENSE environment variable.
+func TranslateOnceFromWavFile(modelPath string, modelName string, file string) {
+	audioConfig, err := audio.NewAudioConfigFromWavFileInput(file)
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer audioConfig.Close()
+
+	config, err := speech.NewEmbeddedSpeechConfigFromPath(modelPath)
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer config.Close()
+
+	// List the translation models available in the configured path.
+	models, err := config.GetSpeechTranslationModels()
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	for _, model := range models {
+		fmt.Printf("Found model: %s (%v -> %v)\n", model.Name(), model.SourceLanguages(), model.TargetLanguages())
+		model.Close()
+	}
+
+	license := os.Getenv("EMBEDDED_SPEECH_MODEL_LICENSE")
+	if err = config.SetSpeechTranslationModel(modelName, license); err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+
+	translationRecognizer, err := speech.NewTranslationRecognizerFromEmbeddedConfig(config, audioConfig)
+	if err != nil {
+		fmt.Println("Got an error: ", err)
+		return
+	}
+	defer translationRecognizer.Close()
+
+	translationRecognizer.SessionStarted(func(event speech.SessionEventArgs) {
+		defer event.Close()
+		fmt.Println("Session Started (ID=", event.SessionID, ")")
+	})
+	translationRecognizer.SessionStopped(func(event speech.SessionEventArgs) {
+		defer event.Close()
+		fmt.Println("Session Stopped (ID=", event.SessionID, ")")
+	})
+
+	task := translationRecognizer.RecognizeOnceAsync()
+	var outcome speech.TranslationRecognitionOutcome
+	select {
+	case outcome = <-task:
+	case <-time.After(15 * time.Second):
+		fmt.Println("Timed out")
+		return
+	}
+	if outcome.Error != nil {
+		fmt.Println("Got an error: ", outcome.Error)
+		return
+	}
+	defer outcome.Result.Close()
+	fmt.Println("Got a translation!")
+	for language, translation := range outcome.Result.GetTranslations() {
+		fmt.Printf("  %s: %s\n", language, translation)
+	}
+}

--- a/samples/main.go
+++ b/samples/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Microsoft/cognitive-services-speech-sdk-go/samples/conversation_transcriber"
 	"github.com/Microsoft/cognitive-services-speech-sdk-go/samples/dialog_service_connector"
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/samples/embedded"
 	"github.com/Microsoft/cognitive-services-speech-sdk-go/samples/recognizer"
 	"github.com/Microsoft/cognitive-services-speech-sdk-go/samples/synthesizer"
 )
@@ -44,6 +45,10 @@ func main() {
 		"speech_synthesizer:SynthesisToSpeaker":                         synthesizer.SynthesisToSpeaker,
 		"speech_synthesizer:SynthesisToAudioDataStream":                 synthesizer.SynthesisToAudioDataStream,
 		"speech_synthesizer:SynthesisFromAutoDetectSourceLangConfig":    synthesizer.SynthesisFromAutoDetectSourceLangConfig,
+		"embedded:RecognizeOnceFromWavFile":                             embedded.RecognizeOnceFromWavFile,
+		"embedded:RecognizeContinuousFromWavFile":                       embedded.RecognizeContinuousFromWavFile,
+		"embedded:SynthesisToWavFile":                                   embedded.SynthesisToWavFile,
+		"embedded:TranslateOnceFromWavFile":                             embedded.TranslateOnceFromWavFile,
 	}
 	args := os.Args[1:]
 	if len(args) != 4 {

--- a/speech/embedded_speech_config.go
+++ b/speech/embedded_speech_config.go
@@ -1,0 +1,196 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+
+package speech
+
+import (
+	"unsafe"
+
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/common"
+)
+
+// #include <stdlib.h>
+// #include <speechapi_c_common.h>
+// #include <speechapi_c_embedded_speech_config.h>
+import "C"
+
+// EmbeddedSpeechConfig defines configurations for embedded (offline) speech recognition, synthesis and
+// translation. An embedded speech config wraps a regular SpeechConfig, so the underlying SpeechConfig can
+// be passed directly to recognizer and synthesizer factory functions (for example
+// NewSpeechRecognizerFromConfig). For translation, use NewTranslationRecognizerFromEmbeddedConfig.
+//
+// Note: Embedded speech recognition, synthesis and translation require licensed models installed on the
+// device and the corresponding native runtime extensions. This is a Limited Access feature.
+type EmbeddedSpeechConfig struct {
+	*SpeechConfig
+}
+
+// GetSpeechConfig returns the underlying SpeechConfig. Use it with the existing recognizer and synthesizer
+// factory functions, for example NewSpeechRecognizerFromConfig or NewSpeechSynthesizerFromConfig.
+func (config *EmbeddedSpeechConfig) GetSpeechConfig() *SpeechConfig {
+	return config.SpeechConfig
+}
+
+func newEmbeddedSpeechConfigFromHandle(handle C.SPXHANDLE) (*EmbeddedSpeechConfig, error) {
+	speechConfig, err := NewSpeechConfigFromHandle(handle2uintptr(handle))
+	if err != nil {
+		return nil, err
+	}
+	config := new(EmbeddedSpeechConfig)
+	config.SpeechConfig = speechConfig
+	return config, nil
+}
+
+// NewEmbeddedSpeechConfigFromPath creates an instance of the embedded speech config with a path to offline
+// speech recognition and/or synthesis models. The path can point to a single model directory or to a root
+// directory that contains multiple models. This method can be called multiple times (through FromPaths) to
+// add several model locations.
+func NewEmbeddedSpeechConfigFromPath(path string) (*EmbeddedSpeechConfig, error) {
+	return NewEmbeddedSpeechConfigFromPaths([]string{path})
+}
+
+// NewEmbeddedSpeechConfigFromPaths creates an instance of the embedded speech config with paths to offline
+// speech recognition and/or synthesis models. Each path can point to a single model directory or to a root
+// directory that contains multiple models.
+func NewEmbeddedSpeechConfigFromPaths(paths []string) (*EmbeddedSpeechConfig, error) {
+	if len(paths) == 0 {
+		return nil, common.NewCarbonError(uintptr(C.SPXERR_INVALID_ARG))
+	}
+	var handle C.SPXHANDLE
+	ret := uintptr(C.embedded_speech_config_create(&handle))
+	if ret != C.SPX_NOERROR {
+		return nil, common.NewCarbonError(ret)
+	}
+	for _, path := range paths {
+		p := C.CString(path)
+		ret = uintptr(C.embedded_speech_config_add_path(handle, p))
+		C.free(unsafe.Pointer(p))
+		if ret != C.SPX_NOERROR {
+			return nil, common.NewCarbonError(ret)
+		}
+	}
+	return newEmbeddedSpeechConfigFromHandle(handle)
+}
+
+// GetSpeechRecognitionModels returns the list of embedded speech recognition models available in the
+// configured model paths. The caller is responsible for calling Close on each returned model.
+func (config *EmbeddedSpeechConfig) GetSpeechRecognitionModels() ([]*SpeechRecognitionModelInfo, error) {
+	var numModels C.uint32_t
+	ret := uintptr(C.embedded_speech_config_get_num_speech_reco_models(config.getHandle(), &numModels))
+	if ret != C.SPX_NOERROR {
+		return nil, common.NewCarbonError(ret)
+	}
+	models := make([]*SpeechRecognitionModelInfo, 0, int(numModels))
+	for i := 0; i < int(numModels); i++ {
+		var modelHandle C.SPXHANDLE
+		ret = uintptr(C.embedded_speech_config_get_speech_reco_model(config.getHandle(), C.uint32_t(i), &modelHandle))
+		if ret != C.SPX_NOERROR {
+			for _, m := range models {
+				m.Close()
+			}
+			return nil, common.NewCarbonError(ret)
+		}
+		models = append(models, newSpeechRecognitionModelFromHandle(modelHandle))
+	}
+	return models, nil
+}
+
+// SetSpeechRecognitionModel sets the model for embedded speech recognition.
+// The name is the model name (see GetSpeechRecognitionModels) and license is the license text for the model.
+func (config *EmbeddedSpeechConfig) SetSpeechRecognitionModel(name string, license string) error {
+	n := C.CString(name)
+	defer C.free(unsafe.Pointer(n))
+	l := C.CString(license)
+	defer C.free(unsafe.Pointer(l))
+	ret := uintptr(C.embedded_speech_config_set_speech_recognition_model(config.getHandle(), n, l))
+	if ret != C.SPX_NOERROR {
+		return common.NewCarbonError(ret)
+	}
+	return nil
+}
+
+// GetSpeechRecognitionModelName returns the model name for embedded speech recognition.
+func (config *EmbeddedSpeechConfig) GetSpeechRecognitionModelName() string {
+	return config.GetProperty(common.SpeechServiceConnectionRecoModelName)
+}
+
+// SetSpeechSynthesisVoice sets the voice for embedded speech synthesis.
+// The name is the voice name and license is the license text for the voice.
+func (config *EmbeddedSpeechConfig) SetSpeechSynthesisVoice(name string, license string) error {
+	n := C.CString(name)
+	defer C.free(unsafe.Pointer(n))
+	l := C.CString(license)
+	defer C.free(unsafe.Pointer(l))
+	ret := uintptr(C.embedded_speech_config_set_speech_synthesis_voice(config.getHandle(), n, l))
+	if ret != C.SPX_NOERROR {
+		return common.NewCarbonError(ret)
+	}
+	return nil
+}
+
+// GetSpeechSynthesisVoiceName returns the voice name for embedded speech synthesis.
+func (config *EmbeddedSpeechConfig) GetSpeechSynthesisVoiceName() string {
+	return config.GetProperty(common.SpeechServiceConnectionSynthOfflineVoice)
+}
+
+// SetKeywordRecognitionModel sets the model for keyword recognition.
+// This is for customer specific models tailored to detect wake words and direct commands.
+// The name is the model name and license is the license text for the model.
+func (config *EmbeddedSpeechConfig) SetKeywordRecognitionModel(name string, license string) error {
+	n := C.CString(name)
+	defer C.free(unsafe.Pointer(n))
+	l := C.CString(license)
+	defer C.free(unsafe.Pointer(l))
+	ret := uintptr(C.embedded_speech_config_set_keyword_recognition_model(config.getHandle(), n, l))
+	if ret != C.SPX_NOERROR {
+		return common.NewCarbonError(ret)
+	}
+	return nil
+}
+
+// GetKeywordRecognitionModelName returns the model name for keyword recognition.
+func (config *EmbeddedSpeechConfig) GetKeywordRecognitionModelName() string {
+	return config.GetProperty(common.KeywordRecognitionModelName)
+}
+
+// GetSpeechTranslationModels returns the list of embedded speech translation models available in the
+// configured model paths. The caller is responsible for calling Close on each returned model.
+func (config *EmbeddedSpeechConfig) GetSpeechTranslationModels() ([]*SpeechTranslationModelInfo, error) {
+	var numModels C.uint32_t
+	ret := uintptr(C.embedded_speech_config_get_num_speech_translation_models(config.getHandle(), &numModels))
+	if ret != C.SPX_NOERROR {
+		return nil, common.NewCarbonError(ret)
+	}
+	models := make([]*SpeechTranslationModelInfo, 0, int(numModels))
+	for i := 0; i < int(numModels); i++ {
+		var modelHandle C.SPXHANDLE
+		ret = uintptr(C.embedded_speech_config_get_speech_translation_model(config.getHandle(), C.uint32_t(i), &modelHandle))
+		if ret != C.SPX_NOERROR {
+			for _, m := range models {
+				m.Close()
+			}
+			return nil, common.NewCarbonError(ret)
+		}
+		models = append(models, newSpeechTranslationModelFromHandle(modelHandle))
+	}
+	return models, nil
+}
+
+// SetSpeechTranslationModel sets the model for embedded speech translation.
+// The name is the model name (see GetSpeechTranslationModels) and license is the license text for the model.
+func (config *EmbeddedSpeechConfig) SetSpeechTranslationModel(name string, license string) error {
+	n := C.CString(name)
+	defer C.free(unsafe.Pointer(n))
+	l := C.CString(license)
+	defer C.free(unsafe.Pointer(l))
+	ret := uintptr(C.embedded_speech_config_set_speech_translation_model(config.getHandle(), n, l))
+	if ret != C.SPX_NOERROR {
+		return common.NewCarbonError(ret)
+	}
+	return nil
+}
+
+// GetSpeechTranslationModelName returns the model name for embedded speech translation.
+func (config *EmbeddedSpeechConfig) GetSpeechTranslationModelName() string {
+	return config.GetProperty(common.SpeechTranslationModelName)
+}

--- a/speech/embedded_speech_config_test.go
+++ b/speech/embedded_speech_config_test.go
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+
+package speech
+
+import (
+	"testing"
+)
+
+func TestEmbeddedConfigFromPath(t *testing.T) {
+	config, err := NewEmbeddedSpeechConfigFromPath("models")
+	if err != nil {
+		t.Error("Unexpected error creating embedded speech config: ", err)
+		return
+	}
+	defer config.Close()
+	if config.GetSpeechConfig() == nil {
+		t.Error("Underlying speech config should not be nil")
+	}
+}
+
+func TestEmbeddedConfigFromPaths(t *testing.T) {
+	config, err := NewEmbeddedSpeechConfigFromPaths([]string{"models1", "models2"})
+	if err != nil {
+		t.Error("Unexpected error creating embedded speech config: ", err)
+		return
+	}
+	defer config.Close()
+	if config.GetSpeechConfig() == nil {
+		t.Error("Underlying speech config should not be nil")
+	}
+}
+
+func TestEmbeddedConfigFromPathsEmpty(t *testing.T) {
+	config, err := NewEmbeddedSpeechConfigFromPaths([]string{})
+	if err == nil {
+		t.Error("Expected an error when no paths are provided")
+	}
+	if config != nil {
+		t.Error("Expected a nil config when no paths are provided")
+	}
+}
+
+func TestEmbeddedConfigRecognitionModel(t *testing.T) {
+	config, err := NewEmbeddedSpeechConfigFromPath("models")
+	if err != nil {
+		t.Error("Unexpected error creating embedded speech config: ", err)
+		return
+	}
+	defer config.Close()
+	name := "en-US model"
+	if err = config.SetSpeechRecognitionModel(name, "license text"); err != nil {
+		t.Error("Unexpected error setting recognition model: ", err)
+	}
+	if config.GetSpeechRecognitionModelName() != name {
+		t.Error("Recognition model name not properly set")
+	}
+}
+
+func TestEmbeddedConfigSynthesisVoice(t *testing.T) {
+	config, err := NewEmbeddedSpeechConfigFromPath("models")
+	if err != nil {
+		t.Error("Unexpected error creating embedded speech config: ", err)
+		return
+	}
+	defer config.Close()
+	name := "en-US voice name"
+	if err = config.SetSpeechSynthesisVoice(name, "license text"); err != nil {
+		t.Error("Unexpected error setting synthesis voice: ", err)
+	}
+	if config.GetSpeechSynthesisVoiceName() != name {
+		t.Error("Synthesis voice name not properly set")
+	}
+}
+
+func TestEmbeddedConfigKeywordModel(t *testing.T) {
+	config, err := NewEmbeddedSpeechConfigFromPath("models")
+	if err != nil {
+		t.Error("Unexpected error creating embedded speech config: ", err)
+		return
+	}
+	defer config.Close()
+	name := "computer"
+	if err = config.SetKeywordRecognitionModel(name, "license text"); err != nil {
+		t.Error("Unexpected error setting keyword model: ", err)
+	}
+	if config.GetKeywordRecognitionModelName() != name {
+		t.Error("Keyword model name not properly set")
+	}
+}
+
+func TestEmbeddedConfigGetSpeechRecognitionModels(t *testing.T) {
+	config, err := NewEmbeddedSpeechConfigFromPath("models")
+	if err != nil {
+		t.Error("Unexpected error creating embedded speech config: ", err)
+		return
+	}
+	defer config.Close()
+	// With no models present in the path this returns an empty list rather than an error.
+	models, err := config.GetSpeechRecognitionModels()
+	if err != nil {
+		t.Error("Unexpected error listing recognition models: ", err)
+		return
+	}
+	for _, model := range models {
+		model.Close()
+	}
+}
+
+func TestEmbeddedConfigTranslationModel(t *testing.T) {
+	config, err := NewEmbeddedSpeechConfigFromPath("models")
+	if err != nil {
+		t.Error("Unexpected error creating embedded speech config: ", err)
+		return
+	}
+	defer config.Close()
+	name := "en-US to many"
+	if err = config.SetSpeechTranslationModel(name, "license text"); err != nil {
+		t.Error("Unexpected error setting translation model: ", err)
+	}
+	if config.GetSpeechTranslationModelName() != name {
+		t.Error("Translation model name not properly set")
+	}
+}
+
+func TestEmbeddedConfigGetSpeechTranslationModels(t *testing.T) {
+	config, err := NewEmbeddedSpeechConfigFromPath("models")
+	if err != nil {
+		t.Error("Unexpected error creating embedded speech config: ", err)
+		return
+	}
+	defer config.Close()
+	// With no models present in the path this returns an empty list rather than an error.
+	models, err := config.GetSpeechTranslationModels()
+	if err != nil {
+		t.Error("Unexpected error listing translation models: ", err)
+		return
+	}
+	for _, model := range models {
+		model.Close()
+	}
+}

--- a/speech/embedded_speech_e2e_test.go
+++ b/speech/embedded_speech_e2e_test.go
@@ -1,0 +1,169 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+
+package speech
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/audio"
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/common"
+)
+
+// These end-to-end tests exercise the embedded (offline) speech features against real licensed models.
+// They only run when the EMBEDDED_MODELS_DIR environment variable points to a directory that contains the
+// offline models and test audio using the following layout:
+//
+//	EMBEDDED_MODELS_DIR=/path/to/models
+//
+// The directory is expected to contain:
+//   - rnnt/Models/FP and rnnt/Models/LP  (speech recognition models)
+//   - rnnt/Models/ST                     (speech translation models)
+//   - audio/whatstheweatherlike.wav      (English utterance)
+//   - audio/de-de/CallTheFirstOne.wav    (German utterance)
+//
+// If the configured models use an empty license/key string, pass "" as the license. Running these tests
+// also requires the embedded runtime extension shared libraries from the Speech SDK embedded package to be
+// discoverable at load time (for example via LD_LIBRARY_PATH on Linux).
+func embeddedModelsDir(t *testing.T) string {
+	dir := os.Getenv("EMBEDDED_MODELS_DIR")
+	if dir == "" {
+		t.Skip("EMBEDDED_MODELS_DIR is not set; skipping embedded end-to-end test")
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Skipf("EMBEDDED_MODELS_DIR %q is not accessible: %v", dir, err)
+	}
+	return dir
+}
+
+func TestEmbeddedSpeechRecognitionE2E(t *testing.T) {
+	root := embeddedModelsDir(t)
+	modelsRoot := filepath.Join(root, "rnnt", "Models")
+	config, err := NewEmbeddedSpeechConfigFromPaths([]string{
+		filepath.Join(modelsRoot, "FP"),
+		filepath.Join(modelsRoot, "LP"),
+	})
+	if err != nil {
+		t.Fatal("Unexpected error creating embedded speech config: ", err)
+	}
+	defer config.Close()
+
+	models, err := config.GetSpeechRecognitionModels()
+	if err != nil {
+		t.Fatal("Unexpected error listing recognition models: ", err)
+	}
+	if len(models) == 0 {
+		t.Fatal("Expected at least one embedded speech recognition model")
+	}
+	model := models[0]
+	t.Logf("Using recognition model: %s (locales: %v)", model.Name(), model.Locales())
+	if err = config.SetSpeechRecognitionModel(model.Name(), ""); err != nil {
+		t.Fatal("Unexpected error setting recognition model: ", err)
+	}
+	for _, m := range models {
+		m.Close()
+	}
+
+	audioConfig, err := audio.NewAudioConfigFromWavFileInput(filepath.Join(root, "audio", "whatstheweatherlike.wav"))
+	if err != nil {
+		t.Fatal("Unexpected error creating audio config: ", err)
+	}
+	defer audioConfig.Close()
+
+	recognizer, err := NewSpeechRecognizerFromConfig(config.GetSpeechConfig(), audioConfig)
+	if err != nil {
+		t.Fatal("Unexpected error creating speech recognizer: ", err)
+	}
+	defer recognizer.Close()
+
+	select {
+	case outcome := <-recognizer.RecognizeOnceAsync():
+		if outcome.Error != nil {
+			t.Fatal("Recognition failed: ", outcome.Error)
+		}
+		defer outcome.Result.Close()
+		if outcome.Result.Reason != common.RecognizedSpeech {
+			t.Fatalf("Unexpected reason: %v", outcome.Result.Reason)
+		}
+		t.Logf("Recognized: %s", outcome.Result.Text)
+		if !strings.Contains(strings.ToLower(outcome.Result.Text), "weather") {
+			t.Errorf("Expected recognized text to contain 'weather', got: %s", outcome.Result.Text)
+		}
+	case <-time.After(60 * time.Second):
+		t.Fatal("Timeout waiting for recognition result")
+	}
+}
+
+func TestEmbeddedSpeechTranslationE2E(t *testing.T) {
+	root := embeddedModelsDir(t)
+	config, err := NewEmbeddedSpeechConfigFromPath(filepath.Join(root, "rnnt", "Models", "ST"))
+	if err != nil {
+		t.Fatal("Unexpected error creating embedded speech config: ", err)
+	}
+	defer config.Close()
+
+	models, err := config.GetSpeechTranslationModels()
+	if err != nil {
+		t.Fatal("Unexpected error listing translation models: ", err)
+	}
+	if len(models) == 0 {
+		t.Fatal("Expected at least one embedded speech translation model")
+	}
+	// Pick a model that translates into English.
+	var selected *SpeechTranslationModelInfo
+	for _, m := range models {
+		for _, target := range m.TargetLanguages() {
+			if strings.HasPrefix(strings.ToLower(target), "en") {
+				selected = m
+				break
+			}
+		}
+		if selected != nil {
+			break
+		}
+	}
+	if selected == nil {
+		selected = models[0]
+	}
+	t.Logf("Using translation model: %s (%v -> %v)", selected.Name(), selected.SourceLanguages(), selected.TargetLanguages())
+	if err = config.SetSpeechTranslationModel(selected.Name(), ""); err != nil {
+		t.Fatal("Unexpected error setting translation model: ", err)
+	}
+	for _, m := range models {
+		m.Close()
+	}
+
+	audioConfig, err := audio.NewAudioConfigFromWavFileInput(filepath.Join(root, "audio", "de-de", "CallTheFirstOne.wav"))
+	if err != nil {
+		t.Fatal("Unexpected error creating audio config: ", err)
+	}
+	defer audioConfig.Close()
+
+	recognizer, err := NewTranslationRecognizerFromEmbeddedConfig(config, audioConfig)
+	if err != nil {
+		t.Fatal("Unexpected error creating translation recognizer: ", err)
+	}
+	defer recognizer.Close()
+
+	select {
+	case outcome := <-recognizer.RecognizeOnceAsync():
+		if outcome.Error != nil {
+			t.Fatal("Translation failed: ", outcome.Error)
+		}
+		defer outcome.Result.Close()
+		if outcome.Result.Reason != common.TranslatedSpeech {
+			t.Fatalf("Unexpected reason: %v", outcome.Result.Reason)
+		}
+		translations := outcome.Result.GetTranslations()
+		t.Logf("Translations: %v", translations)
+		if len(translations) == 0 {
+			t.Error("Expected at least one translation")
+		}
+	case <-time.After(60 * time.Second):
+		t.Fatal("Timeout waiting for translation result")
+	}
+}

--- a/speech/embedded_speech_e2e_test.go
+++ b/speech/embedded_speech_e2e_test.go
@@ -21,7 +21,7 @@ import (
 //	EMBEDDED_MODELS_DIR=/path/to/models
 //
 // The directory is expected to contain:
-//   - rnnt/Models/FP and rnnt/Models/LP  (speech recognition models)
+//   - rnnt/Models/SR                     (speech recognition model)
 //   - rnnt/Models/ST                     (speech translation models)
 //   - audio/whatstheweatherlike.wav      (English utterance)
 //   - audio/de-de/CallTheFirstOne.wav    (German utterance)
@@ -42,11 +42,7 @@ func embeddedModelsDir(t *testing.T) string {
 
 func TestEmbeddedSpeechRecognitionE2E(t *testing.T) {
 	root := embeddedModelsDir(t)
-	modelsRoot := filepath.Join(root, "rnnt", "Models")
-	config, err := NewEmbeddedSpeechConfigFromPaths([]string{
-		filepath.Join(modelsRoot, "FP"),
-		filepath.Join(modelsRoot, "LP"),
-	})
+	config, err := NewEmbeddedSpeechConfigFromPath(filepath.Join(root, "rnnt", "Models", "SR"))
 	if err != nil {
 		t.Fatal("Unexpected error creating embedded speech config: ", err)
 	}

--- a/speech/speech_recognition_model.go
+++ b/speech/speech_recognition_model.go
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+
+package speech
+
+import (
+	"strings"
+
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/common"
+)
+
+// #include <speechapi_c_speech_recognition_model.h>
+import "C"
+
+// SpeechRecognitionModelInfo contains information about a speech recognition model that is
+// available for embedded (offline) speech recognition.
+type SpeechRecognitionModelInfo struct {
+	handle C.SPXHANDLE
+}
+
+// splitLocales splits the pipe-delimited locales string returned by the native layer.
+func splitLocales(locales string) []string {
+	if locales == "" {
+		return []string{}
+	}
+	return strings.Split(locales, "|")
+}
+
+func newSpeechRecognitionModelFromHandle(handle C.SPXHANDLE) *SpeechRecognitionModelInfo {
+	model := new(SpeechRecognitionModelInfo)
+	model.handle = handle
+	return model
+}
+
+// GetHandle gets the handle to the resource (for internal use).
+func (model SpeechRecognitionModelInfo) GetHandle() common.SPXHandle {
+	return handle2uintptr(model.handle)
+}
+
+// Name returns the model name.
+func (model SpeechRecognitionModelInfo) Name() string {
+	return C.GoString(C.speech_recognition_model_get_name(model.handle))
+}
+
+// Locales returns the locales supported by the model.
+func (model SpeechRecognitionModelInfo) Locales() []string {
+	return splitLocales(C.GoString(C.speech_recognition_model_get_locales(model.handle)))
+}
+
+// Path returns the model path.
+func (model SpeechRecognitionModelInfo) Path() string {
+	return C.GoString(C.speech_recognition_model_get_path(model.handle))
+}
+
+// Version returns the model version.
+func (model SpeechRecognitionModelInfo) Version() string {
+	return C.GoString(C.speech_recognition_model_get_version(model.handle))
+}
+
+// Close disposes the associated resources.
+func (model SpeechRecognitionModelInfo) Close() {
+	C.speech_recognition_model_handle_release(model.handle)
+}

--- a/speech/speech_translation_model.go
+++ b/speech/speech_translation_model.go
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+
+package speech
+
+import (
+	"github.com/Microsoft/cognitive-services-speech-sdk-go/common"
+)
+
+// #include <speechapi_c_speech_translation_model.h>
+import "C"
+
+// SpeechTranslationModelInfo contains information about a speech translation model that is
+// available for embedded (offline) speech translation.
+type SpeechTranslationModelInfo struct {
+	handle C.SPXHANDLE
+}
+
+func newSpeechTranslationModelFromHandle(handle C.SPXHANDLE) *SpeechTranslationModelInfo {
+	model := new(SpeechTranslationModelInfo)
+	model.handle = handle
+	return model
+}
+
+// GetHandle gets the handle to the resource (for internal use).
+func (model SpeechTranslationModelInfo) GetHandle() common.SPXHandle {
+	return handle2uintptr(model.handle)
+}
+
+// Name returns the model name.
+func (model SpeechTranslationModelInfo) Name() string {
+	return C.GoString(C.speech_translation_model_get_name(model.handle))
+}
+
+// SourceLanguages returns the source languages supported by the model.
+func (model SpeechTranslationModelInfo) SourceLanguages() []string {
+	return splitLocales(C.GoString(C.speech_translation_model_get_source_languages(model.handle)))
+}
+
+// TargetLanguages returns the target languages supported by the model.
+func (model SpeechTranslationModelInfo) TargetLanguages() []string {
+	return splitLocales(C.GoString(C.speech_translation_model_get_target_languages(model.handle)))
+}
+
+// Path returns the model path.
+func (model SpeechTranslationModelInfo) Path() string {
+	return C.GoString(C.speech_translation_model_get_path(model.handle))
+}
+
+// Version returns the model version.
+func (model SpeechTranslationModelInfo) Version() string {
+	return C.GoString(C.speech_translation_model_get_version(model.handle))
+}
+
+// Close disposes the associated resources.
+func (model SpeechTranslationModelInfo) Close() {
+	C.speech_translation_model_handle_release(model.handle)
+}

--- a/speech/translation_recognizer.go
+++ b/speech/translation_recognizer.go
@@ -70,6 +70,28 @@ func NewTranslationRecognizerFromConfig(config *SpeechTranslationConfig, audioCo
 	return newTranslationRecognizerFromHandle(handle)
 }
 
+// NewTranslationRecognizerFromEmbeddedConfig creates a translation recognizer from an embedded (offline)
+// speech config and audio config. The translation model to be used must be set first through
+// EmbeddedSpeechConfig.SetSpeechTranslationModel.
+func NewTranslationRecognizerFromEmbeddedConfig(config *EmbeddedSpeechConfig, audioConfig *audio.AudioConfig) (*TranslationRecognizer, error) {
+	var handle C.SPXHANDLE
+	if config == nil {
+		return nil, common.NewCarbonError(uintptr(C.SPXERR_INVALID_ARG))
+	}
+	configHandle := uintptr2handle(config.GetHandle())
+	var audioHandle C.SPXHANDLE
+	if audioConfig == nil {
+		audioHandle = nil
+	} else {
+		audioHandle = uintptr2handle(audioConfig.GetHandle())
+	}
+	ret := uintptr(C.recognizer_create_translation_recognizer_from_config(&handle, configHandle, audioHandle))
+	if ret != C.SPX_NOERROR {
+		return nil, common.NewCarbonError(ret)
+	}
+	return newTranslationRecognizerFromHandle(handle)
+}
+
 // NewTranslationRecognizerFromAutoDetectSourceLangConfig creates a translation recognizer from a speech translation config, auto detection source language config and audio config.
 func NewTranslationRecognizerFromAutoDetectSourceLangConfig(config *SpeechTranslationConfig, langConfig *AutoDetectSourceLanguageConfig, audioConfig *audio.AudioConfig) (*TranslationRecognizer, error) {
 	var handle C.SPXHANDLE


### PR DESCRIPTION
**Summary**
Adds embedded (offline) speech recognition, synthesis, and translation to the Go SDK. These run fully on-device without connecting to the cloud Speech service, mirroring the embedded APIs already available in the other language SDKs.

**What's included**
**Core API** 

- EmbeddedSpeechConfig — wraps a regular SpeechConfig; created via NewEmbeddedSpeechConfigFromPath / NewEmbeddedSpeechConfigFromPaths. Supports selecting and querying recognition models, synthesis voices, translation models, and keyword models.
- SpeechRecognitionModelInfo / SpeechTranslationModelInfo — wrappers for enumerating installed models (name, locales/languages, path, version).
- NewTranslationRecognizerFromEmbeddedConfig — offline translation recognizer. Recognition and synthesis reuse the existing factories via config.GetSpeechConfig().

**Common** 

- Adds the embedded-related PropertyID constants (recognition/synthesis/translation/keyword model name + key), with values matching the official SDK.

**Tests**

- Unit tests for EmbeddedSpeechConfig (config creation, model/voice selection, enumeration).
- End-to-end tests gated on EMBEDDED_MODELS_DIR — they self-skip when models aren't present (e.g. in CI).

**Samples & docs**

- embedded — runnable RecognizeOnceFromWavFile, RecognizeContinuousFromWavFile, SynthesisToWavFile, TranslateOnceFromWavFile, plus a README guide covering prerequisites, native-library setup, model/voice installation, build flags, and running.
- Adds an "Embedded (offline) speech" section to the top-level README.

**CI**

- Bumps the Carbon SDK version to 1.50.0 in the GitHub Actions and Azure Pipelines workflows.
