### PR TITLE
Fix truncation of long recognition result text

### DIFF
--- a/speech/speech_recognition_result.go
+++ b/speech/speech_recognition_result.go
@@ -4,7 +4,9 @@
 package speech
 
 import (
+	"bytes"
 	"time"
+	"unicode/utf8"
 	"unsafe"
 
 	"github.com/Microsoft/cognitive-services-speech-sdk-go/common"
@@ -17,6 +19,35 @@ import (
 // #include <speechapi_c_recognizer.h>
 //
 import "C"
+
+const (
+	initialRecognitionResultTextBufferSize = 1024
+	maxRecognitionResultTextBufferSize     = 16 * 1024 * 1024
+)
+
+type recognitionResultTextGetter func(buffer []byte) uintptr
+
+// readRecognitionResultText grows the buffer when the native API reports that
+// it is too small or returns a string that may have been truncated at the end.
+func readRecognitionResultText(getter recognitionResultTextGetter) (string, uintptr) {
+	for bufferSize := initialRecognitionResultTextBufferSize; bufferSize <= maxRecognitionResultTextBufferSize; bufferSize *= 2 {
+		buffer := make([]byte, bufferSize)
+		ret := getter(buffer)
+		if ret == uintptr(C.SPXERR_BUFFER_TOO_SMALL) {
+			continue
+		}
+		if ret != uintptr(C.SPX_NOERROR) {
+			return "", ret
+		}
+
+		terminator := bytes.IndexByte(buffer, 0)
+		if terminator >= 0 && terminator < len(buffer)-utf8.UTFMax {
+			return string(buffer[:terminator]), ret
+		}
+	}
+
+	return "", uintptr(C.SPXERR_BUFFER_TOO_SMALL)
+}
 
 // SpeechRecognitionResult contains detailed information about result of a recognition operation.
 type SpeechRecognitionResult struct {
@@ -67,11 +98,12 @@ func NewSpeechRecognitionResultFromHandle(handle common.SPXHandle) (*SpeechRecog
 	}
 	result.Reason = (common.ResultReason)(cReason)
 	/* Text */
-	ret = uintptr(C.result_get_text(result.handle, (*C.char)(buffer), 1024))
+	result.Text, ret = readRecognitionResultText(func(buffer []byte) uintptr {
+		return uintptr(C.result_get_text(result.handle, (*C.char)(unsafe.Pointer(&buffer[0])), C.uint32_t(len(buffer))))
+	})
 	if ret != C.SPX_NOERROR {
 		return nil, common.NewCarbonError(ret)
 	}
-	result.Text = C.GoString((*C.char)(buffer))
 	/* Duration */
 	var cDuration C.uint64_t
 	ret = uintptr(C.result_get_duration(result.handle, &cDuration))

--- a/speech/speech_recognition_result_test.go
+++ b/speech/speech_recognition_result_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+
+package speech
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestReadRecognitionResultText(t *testing.T) {
+	testCases := []struct {
+		name          string
+		text          string
+		expectedCalls int
+	}{
+		{
+			name:          "short text",
+			text:          strings.Repeat("a", initialRecognitionResultTextBufferSize-utf8.UTFMax-1),
+			expectedCalls: 1,
+		},
+		{
+			name:          "text at initial buffer boundary",
+			text:          strings.Repeat("a", initialRecognitionResultTextBufferSize-1),
+			expectedCalls: 2,
+		},
+		{
+			name:          "long UTF-8 text",
+			text:          strings.Repeat("ก", 400),
+			expectedCalls: 2,
+		},
+		{
+			name:          "long four-byte UTF-8 text",
+			text:          strings.Repeat("😀", 300),
+			expectedCalls: 2,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			calls := 0
+			text, ret := readRecognitionResultText(func(buffer []byte) uintptr {
+				calls++
+				length := len(testCase.text)
+				if length >= len(buffer) {
+					length = len(buffer) - 1
+				}
+				for length > 0 && !utf8.ValidString(testCase.text[:length]) {
+					length--
+				}
+				copy(buffer, testCase.text[:length])
+				buffer[length] = 0
+				return 0
+			})
+
+			if ret != 0 {
+				t.Fatalf("readRecognitionResultText returned error code %#x", ret)
+			}
+			if text != testCase.text {
+				t.Fatalf("readRecognitionResultText returned %d bytes, want %d", len(text), len(testCase.text))
+			}
+			if calls != testCase.expectedCalls {
+				t.Fatalf("readRecognitionResultText called getter %d times, want %d", calls, testCase.expectedCalls)
+			}
+		})
+	}
+}
+
+func TestReadRecognitionResultTextPropagatesError(t *testing.T) {
+	const expected = uintptr(0x1234)
+
+	text, ret := readRecognitionResultText(func(buffer []byte) uintptr {
+		return expected
+	})
+
+	if ret != expected {
+		t.Fatalf("readRecognitionResultText returned error code %#x, want %#x", ret, expected)
+	}
+	if text != "" {
+		t.Fatalf("readRecognitionResultText returned text %q after an error", text)
+	}
+}


### PR DESCRIPTION
## Summary

- replace the fixed 1,024-byte recognition text buffer with a bounded, dynamically growing buffer
- retry when the native API reports `SPXERR_BUFFER_TOO_SMALL` or the returned UTF-8 text may have reached the buffer boundary
- add regression coverage for short text, the exact initial boundary, Thai text, four-byte UTF-8 text, and native error propagation

## Problem

`NewSpeechRecognitionResultFromHandle` always passes a 1,024-byte buffer to `result_get_text`. With current native Speech SDK builds, text longer than that can be returned successfully but truncated to 1,023 bytes plus the terminating NUL. This makes `SpeechRecognitionResult.Text` differ from the full `DisplayText` in the service JSON and disproportionately affects languages that use multi-byte UTF-8 characters.

In a live `th-TH` comparison, the service/Python result contained 1,158 and 1,450 UTF-8 bytes while the unmodified Go binding returned 1,023 bytes for both.

The new helper starts with the existing 1,024-byte allocation and doubles it only when the returned text may have filled the buffer. It retains the native error code behavior and caps allocation at 16 MiB.

## Validation

- `go test ./speech -run '^TestReadRecognitionResultText' -count=1 -v`
- `go test ./... -run '^$' -count=1`
- Ubuntu 24.04 x64 with Speech SDK 1.51.0
- live `th-TH` recognition: Go `Result.Text` matched Python exactly at both 1,158 and 1,450 UTF-8 bytes
